### PR TITLE
engine: try to guess target port when generating proxy streams

### DIFF
--- a/engine/proxy_test.go
+++ b/engine/proxy_test.go
@@ -46,10 +46,28 @@ func TestTargetAddr(t *testing.T) {
 			wantNilErr: true,
 		},
 		{
-			name: "WebAddress",
+			name: "WebAddress port",
+			target: config.Target{
+				AssetType:  config.AssetType(types.WebAddress),
+				Identifier: "https://example.com:1234/path",
+			},
+			want:       "example.com:1234",
+			wantNilErr: true,
+		},
+		{
+			name: "WebAddress scheme",
 			target: config.Target{
 				AssetType:  config.AssetType(types.WebAddress),
 				Identifier: "https://example.com/path",
+			},
+			want:       "example.com:443",
+			wantNilErr: true,
+		},
+		{
+			name: "WebAddress unknown scheme",
+			target: config.Target{
+				AssetType:  config.AssetType(types.WebAddress),
+				Identifier: "unknown://example.com/path",
 			},
 			want:       "example.com",
 			wantNilErr: true,
@@ -69,14 +87,32 @@ func TestTargetAddr(t *testing.T) {
 				AssetType:  config.AssetType(types.GitRepository),
 				Identifier: "git@github.com:adevinta/lava.git",
 			},
-			want:       "github.com",
+			want:       "github.com:22",
 			wantNilErr: true,
 		},
 		{
-			name: "GitRepository URL",
+			name: "GitRepository https",
 			target: config.Target{
 				AssetType:  config.AssetType(types.GitRepository),
-				Identifier: "https://example.com:443/path/to/repo.git/",
+				Identifier: "https://example.com/path/to/repo.git/",
+			},
+			want:       "example.com:443",
+			wantNilErr: true,
+		},
+		{
+			name: "GitRepository git",
+			target: config.Target{
+				AssetType:  config.AssetType(types.GitRepository),
+				Identifier: "git://example.com/~user/path/to/repo.git/",
+			},
+			want:       "example.com:9418",
+			wantNilErr: true,
+		},
+		{
+			name: "GitRepository git port",
+			target: config.Target{
+				AssetType:  config.AssetType(types.GitRepository),
+				Identifier: "git://example.com:443/~user/path/to/repo.git/",
 			},
 			want:       "example.com:443",
 			wantNilErr: true,

--- a/urlutil/urlutil.go
+++ b/urlutil/urlutil.go
@@ -26,8 +26,8 @@ var (
 // if the URL is not valid or if it is not possible to get the
 // contents.
 //
-// It supports the following schemas: http, https. If the provided URL
-// does not specify a schema, it is considered a file path. In the
+// It supports the following schemes: http, https. If the provided URL
+// does not specify a scheme, it is considered a file path. In the
 // case of http and https, the contents are retrieved issuing an HTTP
 // GET request.
 func Get(rawURL string) ([]byte, error) {


### PR DESCRIPTION
In order to proxy a local service, Lava needs to know the port used by
the service. This PR makes possible to guess the port, if it is not
specified, based on the scheme of the target URL. For instance, 443
for `https://`, 9418 for `git://`, etc.