### PR TITLE
internal/config: error when no catalog urls are present

### DIFF
--- a/internal/config/catalog.go
+++ b/internal/config/catalog.go
@@ -16,6 +16,10 @@ import (
 // of the retrieved catalog is not valid.
 var ErrMalformedCatalog = errors.New("malformed catalog")
 
+// ErrMissingCatalog is returned by [NewChecktypeCatalog] when no
+// catalog URLs are provided.
+var ErrMissingCatalog = errors.New("missing catalog URLs")
+
 // ChecktypeCatalog represents a collection of Vulcan checktypes.
 type ChecktypeCatalog map[string]Checktype
 
@@ -24,6 +28,9 @@ type ChecktypeCatalog map[string]Checktype
 // indexed by name. If a checktype is duplicated it is overridden with
 // the last one.
 func NewChecktypeCatalog(urls []string) (ChecktypeCatalog, error) {
+	if len(urls) == 0 {
+		return nil, ErrMissingCatalog
+	}
 	checktypes := make(ChecktypeCatalog)
 	for _, url := range urls {
 		data, err := urlutil.Get(url)

--- a/internal/config/catalog_test.go
+++ b/internal/config/catalog_test.go
@@ -71,6 +71,12 @@ func TestNewChecktypeCatalog(t *testing.T) {
 			want:    nil,
 			wantErr: ErrMalformedCatalog,
 		},
+		{
+			name:    "empty urls",
+			urls:    []string{},
+			want:    nil,
+			wantErr: ErrMissingCatalog,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Emit an error when there is no catalogue configured in lava.yaml