### PR TITLE
report: implement report writer

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -204,18 +204,6 @@ func parseSeverity(severity string) (Severity, error) {
 	return Severity(0), fmt.Errorf("%w: %v", ErrInvalidSeverity, severity)
 }
 
-// UnmarshalYAML decodes a Severity yaml node containing a string into
-// a [Severity] value. It returns error if the provided string does
-// not match any known severity.
-func (s *Severity) UnmarshalYAML(value *yaml.Node) error {
-	severity, err := parseSeverity(value.Value)
-	if err != nil {
-		return err
-	}
-	*s = severity
-	return nil
-}
-
 // IsValid checks if a severity is valid.
 func (s *Severity) IsValid() bool {
 	return *s >= SeverityInfo && *s <= SeverityCritical
@@ -233,7 +221,22 @@ func (s *Severity) String() string {
 
 // MarshalText encode a [Severity] as a text.
 func (s *Severity) MarshalText() (text []byte, err error) {
+	if !s.IsValid() {
+		return nil, ErrInvalidSeverity
+	}
 	return []byte(s.String()), nil
+}
+
+// UnmarshalText decodes a Severity text into a
+// [Severity] value. It returns error if the provided
+// string does not match any known severity.
+func (s *Severity) UnmarshalText(text []byte) error {
+	severity, err := parseSeverity(string(text))
+	if err != nil {
+		return err
+	}
+	*s = severity
+	return nil
 }
 
 // OutputFormat is the format of the generated report.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -187,6 +187,7 @@ const (
 	SeverityInfo     Severity = -3
 )
 
+// severityNames maps each severity name with its level.
 var severityNames = map[string]Severity{
 	"critical": SeverityCritical,
 	"high":     SeverityHigh,
@@ -213,6 +214,26 @@ func (s *Severity) UnmarshalYAML(value *yaml.Node) error {
 	}
 	*s = severity
 	return nil
+}
+
+// IsValid checks if a severity is valid.
+func (s *Severity) IsValid() bool {
+	return *s >= SeverityInfo && *s <= SeverityCritical
+}
+
+// String returns value of a severity.
+func (s *Severity) String() string {
+	for k, v := range severityNames {
+		if v == *s {
+			return k
+		}
+	}
+	return ""
+}
+
+// MarshalText encode a [Severity] as a text.
+func (s *Severity) MarshalText() (text []byte, err error) {
+	return []byte(s.String()), nil
 }
 
 // OutputFormat is the format of the generated report.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -186,3 +186,60 @@ func TestParse(t *testing.T) {
 		})
 	}
 }
+
+func TestSeverity_MarshalText(t *testing.T) {
+	tests := []struct {
+		name     string
+		severity Severity
+		want     string
+		wantErr  error
+	}{
+		{
+			name:     "critical",
+			severity: SeverityCritical,
+			want:     "critical",
+			wantErr:  nil,
+		},
+		{
+			name:     "high",
+			severity: SeverityHigh,
+			want:     "high",
+			wantErr:  nil,
+		},
+		{
+			name:     "medium",
+			severity: SeverityMedium,
+			want:     "medium",
+			wantErr:  nil,
+		},
+		{
+			name:     "low",
+			severity: SeverityLow,
+			want:     "low",
+			wantErr:  nil,
+		},
+		{
+			name:     "info",
+			severity: SeverityInfo,
+			want:     "info",
+			wantErr:  nil,
+		},
+		{
+			name:     "invalid",
+			severity: 7,
+			want:     "",
+			wantErr:  ErrInvalidSeverity,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.severity.MarshalText()
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("unexpected error: want: %v, got: %v", tt.wantErr, err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("unexpected severity string: want: %v, got: %v", tt.want, got)
+			}
+		})
+	}
+}

--- a/internal/report/jsonprinter.go
+++ b/internal/report/jsonprinter.go
@@ -1,0 +1,22 @@
+// Copyright 2023 Adevinta
+
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// jsonPrinter represents a JSON report printer.
+type jsonPrinter struct{}
+
+// Print renders the scan results in JSON format.
+func (prn jsonPrinter) Print(w io.Writer, vulns []vulnerability, _ summary) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(vulns); err != nil {
+		return fmt.Errorf("encode report: %w", err)
+	}
+	return nil
+}

--- a/internal/report/jsonprinter_test.go
+++ b/internal/report/jsonprinter_test.go
@@ -1,0 +1,183 @@
+// Copyright 2023 Adevinta
+
+package report
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	vreport "github.com/adevinta/vulcan-report"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestJsonPrinter_Print(t *testing.T) {
+	tests := []struct {
+		name            string
+		vulnerabilities []vulnerability
+		wantNilErr      bool
+	}{
+		{
+			name: "Standard Output JSON Report",
+			vulnerabilities: []vulnerability{
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 1",
+						Description: "Lorem ipsum dolor sit amet, " +
+							"consectetur adipiscing elit. Nam malesuada " +
+							"pretium ligula, ac egestas leo egestas nec. " +
+							"Morbi id placerat ipsum. Donec semper enim urna, " +
+							"et bibendum ex dictum in. Quisque venenatis " +
+							"in sem in lacinia. Fusce lacus odio, molestie " +
+							"vitae mi nec, elementum pellentesque augue. " +
+							"Aenean imperdiet odio eu sodales molestie. " +
+							"Fusce ut elementum leo. Nam sodales molestie " +
+							"lorem in rutrum. Pellentesque nec sapien elit. " +
+							"Sed tincidunt ut augue sit amet cursus. " +
+							"In convallis magna sit amet tempus pellentesque. " +
+							"Nam commodo porttitor ante sed volutpat. " +
+							"Ut vulputate leo quis ultricies sodales.",
+						AffectedResource: "Affected Resource 1",
+						ImpactDetails:    "Impact detail 1",
+						Recommendations: []string{
+							"Recommendation 1",
+							"Recommendation 2",
+							"Recommendation 3",
+						},
+						Details: "Vulnerability Detail 1",
+						References: []string{
+							"Reference 1",
+							"Reference 2",
+							"Reference 3",
+						},
+						Resources: []vreport.ResourcesGroup{
+							{
+								Name: "Resource 1",
+								Header: []string{
+									"Header 1",
+									"Header 2",
+									"Header 3",
+									"Header 4",
+								},
+								Rows: []map[string]string{
+									{
+										"Header 1": "row 11",
+										"Header 2": "row 12",
+										"Header 3": "row 13",
+										"Header 4": "row 14",
+									},
+									{
+										"Header 1": "row 21",
+										"Header 2": "row 22",
+										"Header 3": "row 23",
+										"Header 4": "row 24",
+									},
+									{
+										"Header 1": "row 31",
+										"Header 2": "row 32",
+										"Header 3": "row 33",
+										"Header 4": "row 34",
+									},
+									{
+										"Header 1": "row 41",
+										"Header 2": "row 42",
+										"Header 3": "row 43",
+										"Header 4": "row 44",
+									},
+								},
+							},
+							{
+								Name: "Resource 2",
+								Header: []string{
+									"Header 1",
+									"Header 2",
+								},
+								Rows: []map[string]string{
+									{
+										"Header 1": "row 11",
+										"Header 2": "row 12",
+									},
+									{
+										"Header 1": "row 21",
+										"Header 2": "row 22",
+									},
+								},
+							},
+							{
+								Name: "Resource 3",
+								Header: []string{
+									"Header 1",
+									"Header 2",
+								},
+								Rows: []map[string]string{
+									{
+										"Header 1": "row 11",
+										"Header 2": "row 12",
+									},
+									{
+										"Header 1": "row 21",
+										"Header 2": "row 22",
+									},
+								},
+							},
+							{
+								Name: "Resource 4",
+								Header: []string{
+									"Header 1",
+									"Header 2",
+								},
+								Rows: []map[string]string{
+									{
+										"Header 1": "row 11",
+										"Header 2": "row 12",
+									},
+									{
+										"Header 1": "row 21",
+										"Header 2": "row 22",
+									},
+								},
+							},
+						},
+					},
+					CheckData: vreport.CheckData{
+						CheckID: "CheckID1",
+					},
+				},
+			},
+			wantNilErr: true,
+		},
+		{
+			name: "No vulnerabilities",
+			vulnerabilities: []vulnerability{
+				{
+					Vulnerability: vreport.Vulnerability{},
+					CheckData: vreport.CheckData{
+						CheckID: "CheckID1",
+					},
+				},
+			},
+			wantNilErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := jsonPrinter{}
+			err := w.Print(&buf, tt.vulnerabilities, summary{})
+			if (err == nil) != tt.wantNilErr {
+				t.Errorf("unexpected error value: %v", err)
+			}
+
+			var got []vulnerability
+			if err = json.Unmarshal(buf.Bytes(), &got); err != nil {
+				t.Errorf("unmarshal json report: %v", err)
+			}
+			diffOpts := []cmp.Option{
+				cmp.AllowUnexported(vulnerability{}),
+			}
+			if diff := cmp.Diff(tt.vulnerabilities, got, diffOpts...); diff != "" {
+				t.Errorf("vulnerabilities mismatch (-want +got):\n%v", diff)
+			}
+		})
+	}
+}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -1,0 +1,266 @@
+// Copyright 2023 Adevinta
+
+// Package report renders Lava reports in different formats using the
+// results returned by the Vulcan checks.
+package report
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"slices"
+
+	report "github.com/adevinta/vulcan-report"
+
+	"github.com/adevinta/lava/internal/config"
+	"github.com/adevinta/lava/internal/engine"
+)
+
+// Writer represents a Lava report writer.
+type Writer struct {
+	prn         printer
+	w           io.WriteCloser
+	minSeverity config.Severity
+	exclusions  []config.Exclusion
+}
+
+// NewWriter creates a new instance of a report writer.
+func NewWriter(cfg config.ReportConfig) (Writer, error) {
+	var prn printer
+	switch cfg.Format {
+	case config.OutputFormatJSON:
+		prn = jsonPrinter{}
+	default:
+		return Writer{}, errors.New("unsupported output format")
+	}
+
+	w := os.Stdout
+	if cfg.OutputFile != "" {
+		f, err := os.Create(cfg.OutputFile)
+		if err != nil {
+			return Writer{}, fmt.Errorf("create file: %w", err)
+		}
+		w = f
+	}
+
+	return Writer{
+		prn:         prn,
+		w:           w,
+		minSeverity: cfg.Severity,
+		exclusions:  cfg.Exclusions,
+	}, nil
+}
+
+// Write renders the provided [engine.Report]. The returned exit code
+// is calculated by evaluating the report with the [config.ReportConfig]
+// passed to [NewWriter]. If the returned error is not nil, the exit code
+// will be zero and should be ignored.
+func (writer Writer) Write(er engine.Report) (ExitCode, error) {
+	vulns, err := writer.parseReport(er)
+	if err != nil {
+		return 0, fmt.Errorf("parse report: %w", err)
+	}
+	sum, err := mkSummary(vulns)
+	if err != nil {
+		return 0, fmt.Errorf("calculate summary: %w", err)
+	}
+	exitCode := writer.calculateExitCode(sum)
+	fvulns := writer.filterVulns(vulns)
+
+	if err = writer.prn.Print(writer.w, fvulns, sum); err != nil {
+		return exitCode, fmt.Errorf("print report: %w", err)
+	}
+
+	return exitCode, nil
+}
+
+// Close closes the [Writer].
+func (writer Writer) Close() error {
+	if err := writer.w.Close(); err != nil {
+		return fmt.Errorf("close writer: %w", err)
+	}
+	return nil
+}
+
+// parseReport converts the provided [engine.Report] into a list of
+// vulnerabilities. It calculates the severity of each vulnerability
+// based on its score and determines if the vulnerability is excluded
+// according to the [Writer] configuration.
+func (writer Writer) parseReport(er engine.Report) ([]vulnerability, error) {
+	var vulns []vulnerability
+	for _, r := range er {
+		for _, vuln := range r.ResultData.Vulnerabilities {
+			severity := scoreToSeverity(vuln.Score)
+
+			excluded, err := writer.isExcluded(vuln, r.Target)
+			if err != nil {
+				return nil, fmt.Errorf("vulnerability exlusion: %w", err)
+			}
+			v := vulnerability{
+				CheckData:     r.CheckData,
+				Vulnerability: vuln,
+				Severity:      severity,
+				excluded:      excluded,
+			}
+			vulns = append(vulns, v)
+		}
+	}
+	return vulns, nil
+}
+
+// isExcluded returns whether the provided [report.Vulnerability] is
+// excluded based on the [Writer] configuration and the affected target.
+func (writer Writer) isExcluded(v report.Vulnerability, target string) (bool, error) {
+	for _, excl := range writer.exclusions {
+		if excl.Fingerprint != "" && v.Fingerprint != excl.Fingerprint {
+			continue
+		}
+
+		if excl.Summary != "" {
+			matched, err := regexp.MatchString(excl.Summary, v.Summary)
+			if err != nil {
+				return false, fmt.Errorf("match string: %w", err)
+			}
+			if !matched {
+				continue
+			}
+		}
+
+		if excl.Target != "" {
+			matched, err := regexp.MatchString(excl.Target, target)
+			if err != nil {
+				return false, fmt.Errorf("match string: %w", err)
+			}
+			if !matched {
+				continue
+			}
+		}
+
+		if excl.Resource != "" {
+			matched, err := regexp.MatchString(excl.Resource, v.AffectedResource)
+			if err != nil {
+				return false, fmt.Errorf("match string: %w", err)
+			}
+			if !matched {
+				continue
+			}
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// filterVulns takes a list of vulnerabilities and filters out those
+// vulnerabilities that should be excluded based on the [Writer]
+// configuration.
+func (writer Writer) filterVulns(vulns []vulnerability) []vulnerability {
+	// Sort the results by severity in reverse order.
+	slices.SortFunc(vulns, func(a, b vulnerability) int {
+		return cmp.Compare(b.Severity, a.Severity)
+	})
+
+	var fvulns []vulnerability
+	for _, v := range vulns {
+		if v.Severity < writer.minSeverity {
+			break
+		}
+		if v.excluded {
+			continue
+		}
+		fvulns = append(fvulns, v)
+	}
+	return fvulns
+}
+
+// calculateExitCode returns an error code depending on the vulnerabilities found,
+// as long as the severity of the vulnerabilities is higher or equal than the
+// min severity configured in the writer. For that it makes use of the summary.
+//
+// See [ExitCode] for more information about exit codes.
+func (writer Writer) calculateExitCode(sum summary) ExitCode {
+	for sev := config.SeverityCritical; sev >= writer.minSeverity; sev-- {
+		if sum.count[sev] > 0 {
+			diff := sev - config.SeverityInfo
+			return ExitCodeInfo + ExitCode(diff)
+		}
+	}
+	return 0
+}
+
+// vulnerability represents a vulnerability found by a check.
+type vulnerability struct {
+	report.Vulnerability
+	CheckData report.CheckData `json:"check_data"`
+	Severity  config.Severity  `json:"severity"`
+	excluded  bool
+}
+
+// A printer renders a Vulcan report in a specific format.
+type printer interface {
+	Print(w io.Writer, vulns []vulnerability, sum summary) error
+}
+
+// scoreToSeverity converts a CVSS score into a [config.Severity].
+// To calculate the severity we are using the [severity ratings]
+// provided by the NVD.
+//
+// [severity ratings]: https://nvd.nist.gov/vuln-metrics/cvss
+func scoreToSeverity(score float32) config.Severity {
+	switch {
+	case score >= 9.0:
+		return config.SeverityCritical
+	case score >= 7.0:
+		return config.SeverityHigh
+	case score >= 4.0:
+		return config.SeverityMedium
+	case score >= 0.1:
+		return config.SeverityLow
+	default:
+		return config.SeverityInfo
+	}
+}
+
+// summary represents the statistics of the results.
+type summary struct {
+	count    map[config.Severity]int
+	excluded int
+}
+
+// mkSummary counts the number vulnerabilities per severity and the
+// number of excluded vulnerabilities. The excluded vulnerabilities are
+// not considered in the count per severity.
+func mkSummary(vulns []vulnerability) (summary, error) {
+	if len(vulns) == 0 {
+		return summary{}, nil
+	}
+
+	sum := summary{
+		count: make(map[config.Severity]int),
+	}
+	for _, vuln := range vulns {
+		if !vuln.Severity.IsValid() {
+			return summary{}, fmt.Errorf("invalid severity: %v", vuln.Severity)
+		}
+		if vuln.excluded {
+			sum.excluded++
+		} else {
+			sum.count[vuln.Severity]++
+		}
+	}
+	return sum, nil
+}
+
+// ExitCode represents an exit code depending on the vulnerabilities found.
+type ExitCode int
+
+// Exit codes depending on the maximum severity found.
+const (
+	ExitCodeCritical ExitCode = 104
+	ExitCodeHigh     ExitCode = 103
+	ExitCodeMedium   ExitCode = 102
+	ExitCodeLow      ExitCode = 101
+	ExitCodeInfo     ExitCode = 100
+)

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1,0 +1,1044 @@
+// Copyright 2023 Adevinta
+
+package report
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	vreport "github.com/adevinta/vulcan-report"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/adevinta/lava/internal/config"
+	"github.com/adevinta/lava/internal/engine"
+)
+
+func TestWriter_calculateExitCode(t *testing.T) {
+	tests := []struct {
+		name    string
+		sum     summary
+		rConfig config.ReportConfig
+		want    ExitCode
+	}{
+		{
+			name: "critical",
+			sum: summary{
+				count: map[config.Severity]int{
+					config.SeverityCritical: 1,
+					config.SeverityHigh:     1,
+					config.SeverityMedium:   1,
+					config.SeverityLow:      1,
+					config.SeverityInfo:     1,
+				},
+			},
+			rConfig: config.ReportConfig{
+				Severity: config.SeverityInfo,
+			},
+			want: ExitCodeCritical,
+		},
+		{
+			name: "high",
+			sum: summary{
+				count: map[config.Severity]int{
+					config.SeverityCritical: 0,
+					config.SeverityHigh:     1,
+					config.SeverityMedium:   1,
+					config.SeverityLow:      1,
+					config.SeverityInfo:     1,
+				},
+			},
+			rConfig: config.ReportConfig{
+				Severity: config.SeverityInfo,
+			},
+			want: ExitCodeHigh,
+		},
+		{
+			name: "medium",
+			sum: summary{
+				count: map[config.Severity]int{
+					config.SeverityCritical: 0,
+					config.SeverityHigh:     0,
+					config.SeverityMedium:   1,
+					config.SeverityLow:      1,
+					config.SeverityInfo:     1,
+				},
+			},
+			rConfig: config.ReportConfig{
+				Severity: config.SeverityInfo,
+			},
+			want: ExitCodeMedium,
+		},
+		{
+			name: "low",
+			sum: summary{
+				count: map[config.Severity]int{
+					config.SeverityCritical: 0,
+					config.SeverityHigh:     0,
+					config.SeverityMedium:   0,
+					config.SeverityLow:      1,
+					config.SeverityInfo:     1,
+				},
+			},
+			rConfig: config.ReportConfig{
+				Severity: config.SeverityInfo,
+			},
+			want: ExitCodeLow,
+		},
+		{
+			name: "info",
+			sum: summary{
+				count: map[config.Severity]int{
+					config.SeverityCritical: 0,
+					config.SeverityHigh:     0,
+					config.SeverityMedium:   0,
+					config.SeverityLow:      0,
+					config.SeverityInfo:     1,
+				},
+			},
+			rConfig: config.ReportConfig{
+				Severity: config.SeverityInfo,
+			},
+			want: ExitCodeInfo,
+		},
+		{
+			name: "no exit code",
+			sum: summary{
+				count: map[config.Severity]int{
+					config.SeverityCritical: 0,
+					config.SeverityHigh:     0,
+					config.SeverityMedium:   1,
+					config.SeverityLow:      1,
+					config.SeverityInfo:     1,
+				},
+			},
+			rConfig: config.ReportConfig{
+				Severity: config.SeverityHigh,
+			},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, err := NewWriter(tt.rConfig)
+			if err != nil {
+				t.Fatalf("unable to create a report writer: %v", err)
+			}
+			got := w.calculateExitCode(tt.sum)
+			if got != tt.want {
+				t.Errorf("unexpected exit code: got: %v, want: %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScoreToSeverity(t *testing.T) {
+	tests := []struct {
+		name  string
+		score float32
+		want  config.Severity
+	}{
+		{
+			name:  "critical",
+			score: 9,
+			want:  config.SeverityCritical,
+		},
+		{
+			name:  "high",
+			score: 7,
+			want:  config.SeverityHigh,
+		},
+		{
+			name:  "medium",
+			score: 4,
+			want:  config.SeverityMedium,
+		},
+		{
+			name:  "low",
+			score: 0.1,
+			want:  config.SeverityLow,
+		},
+		{
+			name:  "info",
+			score: 0,
+			want:  config.SeverityInfo,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scoreToSeverity(tt.score)
+			if got != tt.want {
+				t.Errorf("unexpected severity: got: %v, want: %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWriter_parseReport(t *testing.T) {
+	tests := []struct {
+		name       string
+		report     engine.Report
+		rConfig    config.ReportConfig
+		want       []vulnerability
+		wantNilErr bool
+	}{
+		{
+			name: "all vulnerabilities included",
+			report: map[string]vreport.Report{
+				"CheckID1": {
+					CheckData: vreport.CheckData{
+						CheckID: "CheckID1",
+					},
+					ResultData: vreport.ResultData{
+						Vulnerabilities: []vreport.Vulnerability{
+							{
+								Summary: "Vulnerability Summary 1",
+							},
+						},
+					},
+				},
+				"CheckID2": {
+					CheckData: vreport.CheckData{
+						CheckID: "CheckID2",
+					},
+					ResultData: vreport.ResultData{
+						Vulnerabilities: []vreport.Vulnerability{
+							{
+								Summary: "Vulnerability Summary 2",
+								Score:   6.7,
+							},
+						},
+					},
+				},
+			},
+			rConfig: config.ReportConfig{
+				Exclusions: []config.Exclusion{},
+			},
+			want: []vulnerability{
+				{
+					CheckData: vreport.CheckData{
+						CheckID: "CheckID1",
+					},
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 1",
+					},
+					Severity: config.SeverityInfo,
+					excluded: false,
+				},
+				{
+					CheckData: vreport.CheckData{
+						CheckID: "CheckID2",
+					},
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 2",
+						Score:   6.7,
+					},
+					Severity: config.SeverityMedium,
+					excluded: false,
+				},
+			},
+			wantNilErr: true,
+		},
+		{
+			name: "some vulnerabilities excluded",
+			report: map[string]vreport.Report{
+				"CheckID1": {
+					CheckData: vreport.CheckData{
+						CheckID: "CheckID1",
+					},
+					ResultData: vreport.ResultData{
+						Vulnerabilities: []vreport.Vulnerability{
+							{
+								Summary: "Vulnerability Summary 1",
+							},
+						},
+					},
+				},
+				"CheckID2": {
+					CheckData: vreport.CheckData{
+						CheckID: "CheckID2",
+					},
+					ResultData: vreport.ResultData{
+						Vulnerabilities: []vreport.Vulnerability{
+							{
+								Summary: "Vulnerability Summary 2",
+								Score:   6.7,
+							},
+						},
+					},
+				},
+			},
+			rConfig: config.ReportConfig{
+				Exclusions: []config.Exclusion{
+					{Summary: "Summary 2"},
+				},
+			},
+			want: []vulnerability{
+				{
+					CheckData: vreport.CheckData{
+						CheckID: "CheckID1",
+					},
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 1",
+					},
+					Severity: config.SeverityInfo,
+					excluded: false,
+				},
+				{
+					CheckData: vreport.CheckData{
+						CheckID: "CheckID2",
+					},
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 2",
+						Score:   6.7,
+					},
+					Severity: config.SeverityMedium,
+					excluded: true,
+				},
+			},
+			wantNilErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, err := NewWriter(tt.rConfig)
+			if err != nil {
+				t.Fatalf("unable to create a report writer: %v", err)
+			}
+			got, err := w.parseReport(tt.report)
+			if (err == nil) != tt.wantNilErr {
+				t.Errorf("unexpected error value: %v", err)
+			}
+			diffOpts := []cmp.Option{
+				cmp.AllowUnexported(vulnerability{}),
+				cmpopts.SortSlices(vulnLess),
+			}
+			if diff := cmp.Diff(tt.want, got, diffOpts...); diff != "" {
+				t.Errorf("vulnerabilities mismatch (-want +got):\n%v", diff)
+			}
+		})
+	}
+}
+
+func TestWriter_isExcluded(t *testing.T) {
+	tests := []struct {
+		name          string
+		vulnerability vreport.Vulnerability
+		target        string
+		rConfig       config.ReportConfig
+		want          bool
+		wantNilErr    bool
+	}{
+		{
+			name: "empty exclusions",
+			vulnerability: vreport.Vulnerability{
+				Summary: "Vulnerability Summary 1",
+				Score:   6.7,
+			},
+			target: ".",
+			rConfig: config.ReportConfig{
+				Exclusions: []config.Exclusion{},
+			},
+			want:       false,
+			wantNilErr: true,
+		},
+		{
+			name: "exclude by summary",
+			vulnerability: vreport.Vulnerability{
+				Summary: "Vulnerability Summary 1",
+				Score:   6.7,
+			},
+			target: ".",
+			rConfig: config.ReportConfig{
+				Exclusions: []config.Exclusion{
+					{
+						Summary:     "Summary 1",
+						Description: "Excluded vulnerabilities Summary 1",
+					},
+				},
+			},
+			want:       true,
+			wantNilErr: true,
+		},
+		{
+			name: "not exclude by summary",
+			vulnerability: vreport.Vulnerability{
+				Summary: "Vulnerability Summary 1",
+				Score:   6.7,
+			},
+			target: ".",
+			rConfig: config.ReportConfig{
+				Exclusions: []config.Exclusion{
+					{
+						Summary:     "Summary 2",
+						Description: "Excluded vulnerabilities Summary 2",
+					},
+				},
+			},
+			want:       false,
+			wantNilErr: true,
+		},
+		{
+			name: "exclude by fingerprint",
+			vulnerability: vreport.Vulnerability{
+				Summary:     "Vulnerability Summary 1",
+				Score:       6.7,
+				Fingerprint: "12345",
+			},
+			target: ".",
+			rConfig: config.ReportConfig{
+				Exclusions: []config.Exclusion{
+					{
+						Fingerprint: "12345",
+					},
+				},
+			},
+			want:       true,
+			wantNilErr: true,
+		},
+		{
+			name: "exclude by affected resource",
+			vulnerability: vreport.Vulnerability{
+				Summary:          "Vulnerability Summary 1",
+				Score:            6.7,
+				AffectedResource: "Resource 1",
+			},
+			target: ".",
+			rConfig: config.ReportConfig{
+				Exclusions: []config.Exclusion{
+					{
+						Resource: "Resource 1",
+					},
+				},
+			},
+			want:       true,
+			wantNilErr: true,
+		},
+		{
+			name: "exclude by target",
+			vulnerability: vreport.Vulnerability{
+				Summary: "Vulnerability Summary 1",
+				Score:   6.7,
+			},
+			target: ".",
+			rConfig: config.ReportConfig{
+				Exclusions: []config.Exclusion{
+					{
+						Target: ".",
+					},
+				},
+			},
+			want:       true,
+			wantNilErr: true,
+		},
+		{
+			name: "match all exclusion criteria",
+			vulnerability: vreport.Vulnerability{
+				Summary:          "Vulnerability Summary 1",
+				Score:            6.7,
+				AffectedResource: "Resource 1",
+				Fingerprint:      "12345",
+			},
+			target: ".",
+			rConfig: config.ReportConfig{
+				Exclusions: []config.Exclusion{
+					{
+						Summary:     "Summary 1",
+						Resource:    "Resource 1",
+						Fingerprint: "12345",
+						Target:      ".",
+					},
+				},
+			},
+			want:       true,
+			wantNilErr: true,
+		},
+		{
+			name: "fail an exclusion criteria",
+			vulnerability: vreport.Vulnerability{
+				Summary:          "Vulnerability Summary 1",
+				Score:            6.7,
+				AffectedResource: "Resource 1",
+				Fingerprint:      "12345",
+			},
+			target: ".",
+			rConfig: config.ReportConfig{
+				Exclusions: []config.Exclusion{
+					{
+						Summary:     "Summary 1",
+						Resource:    "Resource 1",
+						Fingerprint: "abcdefg",
+						Target:      ".",
+					},
+				},
+			},
+			want:       false,
+			wantNilErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, err := NewWriter(tt.rConfig)
+			if err != nil {
+				t.Fatalf("unable to create a report writer: %v", err)
+			}
+			got, err := w.isExcluded(tt.vulnerability, tt.target)
+			if (err == nil) != tt.wantNilErr {
+				t.Errorf("unexpected error value: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("unexpected excluded value: got: %v, want: %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMkSummary(t *testing.T) {
+	tests := []struct {
+		name            string
+		vulnerabilities []vulnerability
+		want            summary
+		wantNilErr      bool
+	}{
+		{
+			name: "happy path",
+			vulnerabilities: []vulnerability{
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 1",
+					},
+					Severity: config.SeverityCritical,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 2",
+					},
+					Severity: config.SeverityCritical,
+					excluded: true,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 3",
+					},
+					Severity: config.SeverityHigh,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 4",
+					},
+					Severity: config.SeverityHigh,
+					excluded: true,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 5",
+					},
+					Severity: config.SeverityMedium,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 6",
+					},
+					Severity: config.SeverityMedium,
+					excluded: true,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 7",
+					},
+					Severity: config.SeverityLow,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 8",
+					},
+					Severity: config.SeverityLow,
+					excluded: true,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 9",
+					},
+					Severity: config.SeverityInfo,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 10",
+					},
+					Severity: config.SeverityInfo,
+					excluded: true,
+				},
+			},
+			want: summary{
+				count: map[config.Severity]int{
+					config.SeverityCritical: 1,
+					config.SeverityHigh:     1,
+					config.SeverityMedium:   1,
+					config.SeverityLow:      1,
+					config.SeverityInfo:     1,
+				},
+				excluded: 5,
+			},
+			wantNilErr: true,
+		},
+		{
+			name: "unknown severity",
+			vulnerabilities: []vulnerability{
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 1",
+					},
+					Severity: 7,
+					excluded: false,
+				},
+			},
+			want: summary{
+				count:    nil,
+				excluded: 0,
+			},
+			wantNilErr: false,
+		},
+		{
+			name:            "empty summary",
+			vulnerabilities: []vulnerability{},
+			want: summary{
+				count:    nil,
+				excluded: 0,
+			},
+			wantNilErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mkSummary(tt.vulnerabilities)
+			if (err == nil) != tt.wantNilErr {
+				t.Errorf("unexpected error value: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(summary{})); diff != "" {
+				t.Errorf("summary mismatch (-want +got):\n%v", diff)
+			}
+		})
+	}
+}
+
+func TestWriter_filterVulns(t *testing.T) {
+	tests := []struct {
+		name            string
+		vulnerabilities []vulnerability
+		rConfig         config.ReportConfig
+		want            []vulnerability
+	}{
+		{
+			name: "filter excluded",
+			vulnerabilities: []vulnerability{
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 1",
+					},
+					Severity: config.SeverityCritical,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 2",
+					},
+					Severity: config.SeverityCritical,
+					excluded: true,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 3",
+					},
+					Severity: config.SeverityHigh,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 4",
+					},
+					Severity: config.SeverityHigh,
+					excluded: true,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 5",
+					},
+					Severity: config.SeverityMedium,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 6",
+					},
+					Severity: config.SeverityMedium,
+					excluded: true,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 7",
+					},
+					Severity: config.SeverityLow,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 8",
+					},
+					Severity: config.SeverityLow,
+					excluded: true,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 9",
+					},
+					Severity: config.SeverityInfo,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 10",
+					},
+					Severity: config.SeverityInfo,
+					excluded: true,
+				},
+			},
+			rConfig: config.ReportConfig{
+				Severity: config.SeverityInfo,
+			},
+			want: []vulnerability{
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 1",
+					},
+					Severity: config.SeverityCritical,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 3",
+					},
+					Severity: config.SeverityHigh,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 5",
+					},
+					Severity: config.SeverityMedium,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 7",
+					},
+					Severity: config.SeverityLow,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 9",
+					},
+					Severity: config.SeverityInfo,
+					excluded: false,
+				},
+			},
+		},
+		{
+			name: "filter excluded and lower than high",
+			vulnerabilities: []vulnerability{
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 1",
+					},
+					Severity: config.SeverityCritical,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 2",
+					},
+					Severity: config.SeverityCritical,
+					excluded: true,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 3",
+					},
+					Severity: config.SeverityHigh,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 4",
+					},
+					Severity: config.SeverityHigh,
+					excluded: true,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 5",
+					},
+					Severity: config.SeverityMedium,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 6",
+					},
+					Severity: config.SeverityMedium,
+					excluded: true,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 7",
+					},
+					Severity: config.SeverityLow,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 8",
+					},
+					Severity: config.SeverityLow,
+					excluded: true,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 9",
+					},
+					Severity: config.SeverityInfo,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 10",
+					},
+					Severity: config.SeverityInfo,
+					excluded: true,
+				},
+			},
+			rConfig: config.ReportConfig{
+				Severity: config.SeverityHigh,
+			},
+			want: []vulnerability{
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 1",
+					},
+					Severity: config.SeverityCritical,
+					excluded: false,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 3",
+					},
+					Severity: config.SeverityHigh,
+					excluded: false,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, err := NewWriter(tt.rConfig)
+			if err != nil {
+				t.Fatalf("unable to create a report writer: %v", err)
+			}
+			got := w.filterVulns(tt.vulnerabilities)
+			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(vulnerability{})); diff != "" {
+				t.Errorf("summary mismatch (-want +got):\n%v", diff)
+			}
+		})
+	}
+}
+
+func TestNewWriter_OutputFile(t *testing.T) {
+	tests := []struct {
+		name         string
+		report       engine.Report
+		rConfig      config.ReportConfig
+		wantExitCode ExitCode
+		wantNilErr   bool
+	}{
+		{
+			name: "Standard Output JSON Report",
+			report: map[string]vreport.Report{
+				"CheckID1": {
+					CheckData: vreport.CheckData{
+						CheckID: "CheckID1",
+					},
+					ResultData: vreport.ResultData{
+						Vulnerabilities: []vreport.Vulnerability{
+							{
+								Summary: "Vulnerability Summary 1",
+								Description: "Lorem ipsum dolor sit amet, " +
+									"consectetur adipiscing elit. Nam malesuada " +
+									"pretium ligula, ac egestas leo egestas nec. " +
+									"Morbi id placerat ipsum. Donec semper enim urna, " +
+									"et bibendum ex dictum in. Quisque venenatis " +
+									"in sem in lacinia. Fusce lacus odio, molestie " +
+									"vitae mi nec, elementum pellentesque augue. " +
+									"Aenean imperdiet odio eu sodales molestie. " +
+									"Fusce ut elementum leo. Nam sodales molestie " +
+									"lorem in rutrum. Pellentesque nec sapien elit. " +
+									"Sed tincidunt ut augue sit amet cursus. " +
+									"In convallis magna sit amet tempus pellentesque. " +
+									"Nam commodo porttitor ante sed volutpat. " +
+									"Ut vulputate leo quis ultricies sodales.",
+								AffectedResource: "Affected Resource 1",
+								ImpactDetails:    "Impact detail 1",
+								Recommendations: []string{
+									"Recommendation 1",
+									"Recommendation 2",
+									"Recommendation 3",
+								},
+								Details: "Vulnerability Detail 1",
+								References: []string{
+									"Reference 1",
+									"Reference 2",
+									"Reference 3",
+								},
+								Resources: []vreport.ResourcesGroup{
+									{
+										Name: "Resource 1",
+										Header: []string{
+											"Header 1",
+											"Header 2",
+											"Header 3",
+											"Header 4",
+										},
+										Rows: []map[string]string{
+											{
+												"Header 1": "row 11",
+												"Header 2": "row 12",
+												"Header 3": "row 13",
+												"Header 4": "row 14",
+											},
+											{
+												"Header 1": "row 21",
+												"Header 2": "row 22",
+												"Header 3": "row 23",
+												"Header 4": "row 24",
+											},
+											{
+												"Header 1": "row 31",
+												"Header 2": "row 32",
+												"Header 3": "row 33",
+												"Header 4": "row 34",
+											},
+											{
+												"Header 1": "row 41",
+												"Header 2": "row 42",
+												"Header 3": "row 43",
+												"Header 4": "row 44",
+											},
+										},
+									},
+									{
+										Name: "Resource 2",
+										Header: []string{
+											"Header 1",
+											"Header 2",
+										},
+										Rows: []map[string]string{
+											{
+												"Header 1": "row 11",
+												"Header 2": "row 12",
+											},
+											{
+												"Header 1": "row 21",
+												"Header 2": "row 22",
+											},
+										},
+									},
+									{
+										Name: "Resource 3",
+										Header: []string{
+											"Header 1",
+											"Header 2",
+										},
+										Rows: []map[string]string{
+											{
+												"Header 1": "row 11",
+												"Header 2": "row 12",
+											},
+											{
+												"Header 1": "row 21",
+												"Header 2": "row 22",
+											},
+										},
+									},
+									{
+										Name: "Resource 4",
+										Header: []string{
+											"Header 1",
+											"Header 2",
+										},
+										Rows: []map[string]string{
+											{
+												"Header 1": "row 11",
+												"Header 2": "row 12",
+											},
+											{
+												"Header 1": "row 21",
+												"Header 2": "row 22",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			rConfig: config.ReportConfig{
+				Severity:   config.SeverityInfo,
+				OutputFile: "test.json",
+				Format:     config.OutputFormatJSON,
+			},
+			wantExitCode: ExitCodeInfo,
+			wantNilErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpPath, err := os.MkdirTemp("", "")
+			if err != nil {
+				t.Fatalf("unable to create a temporary dir")
+			}
+			defer os.RemoveAll(tmpPath)
+
+			tt.rConfig.OutputFile = path.Join(tmpPath, tt.rConfig.OutputFile)
+			writer, err := NewWriter(tt.rConfig)
+			if err != nil {
+				t.Fatalf("unable to create a report writer: %v", err)
+			}
+			defer writer.Close()
+			gotExitCode, err := writer.Write(tt.report)
+			if (err == nil) != tt.wantNilErr {
+				t.Errorf("unexpected error value: %v", err)
+			}
+			if gotExitCode != tt.wantExitCode {
+				t.Errorf("unexpected error value: got: %d, want: %d", gotExitCode, tt.wantExitCode)
+			}
+
+			if _, err = os.Stat(tt.rConfig.OutputFile); err != nil {
+				t.Fatalf("unexpected error value: %v", err)
+			}
+		})
+	}
+}
+
+func vulnLess(a, b vulnerability) bool {
+	h := func(v vulnerability) string {
+		return fmt.Sprintf("%#v", v)
+	}
+	return h(a) < h(b)
+}


### PR DESCRIPTION
This PR adds a new report writer.
As preliminary steps to that, it parses the report generated by vulcan-agent and filters the vulnerabilities according to their severity and exclusion criteria.