### PR TITLE
internal/engine: fix bug handling proxy.Group errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/jroimartin/clilog v0.1.1
-	github.com/jroimartin/proxy v0.3.0
+	github.com/jroimartin/proxy v0.3.1
 	golang.org/x/mod v0.12.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -234,8 +234,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/jroimartin/clilog v0.1.1 h1:V/pAhLUCLR0ccQTWkRq1zCVqJjwj/YreVAJ2QsntsdQ=
 github.com/jroimartin/clilog v0.1.1/go.mod h1:ArefLtV3/IjCdl/sJS61pBnzWPDOL6r9uw2argb3N1M=
-github.com/jroimartin/proxy v0.3.0 h1:DThVnxv+2txLi50dkYpZcKUd2YtMyt+qvUMb9dnoGWQ=
-github.com/jroimartin/proxy v0.3.0/go.mod h1:ZcNCwQkEK34eWhlE/pxs/N8DhnlWUlAmdvsWRgdwxCQ=
+github.com/jroimartin/proxy v0.3.1 h1:8TTmHvheP+xsRA43dETDnrnOtsCirMGd/fDtjMtzXgM=
+github.com/jroimartin/proxy v0.3.1/go.mod h1:ZcNCwQkEK34eWhlE/pxs/N8DhnlWUlAmdvsWRgdwxCQ=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/internal/engine/targetserver.go
+++ b/internal/engine/targetserver.go
@@ -157,12 +157,17 @@ func (srv *targetServer) handle(target config.Target) (targetMap, error) {
 loop:
 	for {
 		select {
-		case err := <-errc:
+		case err, ok := <-errc:
+			// No listeners.
+			if !ok {
+				break loop
+			}
+
 			// If there is a service already listening on
 			// that address, then assume that it is the
 			// target service and ignore the error.
 			if errors.Is(err, syscall.EADDRINUSE) {
-				continue
+				break loop
 			}
 
 			// An unexpected error happened in one of the


### PR DESCRIPTION
This PR fixes a bug on how `*targetServer.handle` handles errors
coming from `*proxy.Group.ListenAndServe`.

This PR also updates github.com/jroimartin/proxy to v0.3.1.

github.com/jroimartin/proxy@v0.3.1 fixes `*Group.ListenAndServe` error
handling. For more details, please see https://github.com/jroimartin/proxy/pull/12