### PR TITLE
go.mod: upgrade github.com/jroimartin/proxy to v0.4.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/jroimartin/clilog v0.1.1
-	github.com/jroimartin/proxy v0.4.2
+	github.com/jroimartin/proxy v0.4.3
 	golang.org/x/mod v0.12.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -234,8 +234,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/jroimartin/clilog v0.1.1 h1:V/pAhLUCLR0ccQTWkRq1zCVqJjwj/YreVAJ2QsntsdQ=
 github.com/jroimartin/clilog v0.1.1/go.mod h1:ArefLtV3/IjCdl/sJS61pBnzWPDOL6r9uw2argb3N1M=
-github.com/jroimartin/proxy v0.4.2 h1:XQssbftqnRPR09e2bTX3Kds7BjNv4TbQnSgO5190DwY=
-github.com/jroimartin/proxy v0.4.2/go.mod h1:ZcNCwQkEK34eWhlE/pxs/N8DhnlWUlAmdvsWRgdwxCQ=
+github.com/jroimartin/proxy v0.4.3 h1:NTzFp4phDiXBKcxNO/pPveoK0mWLr+VVo1NXzMXJQnQ=
+github.com/jroimartin/proxy v0.4.3/go.mod h1:ZcNCwQkEK34eWhlE/pxs/N8DhnlWUlAmdvsWRgdwxCQ=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=


### PR DESCRIPTION
This PR upgrades github.com/jroimartin/proxy to v0.4.3.

For more details, please see:

- https://github.com/jroimartin/proxy/pull/16