### PR TITLE
internal/config: fix config.Exclusion docs

### DIFF
--- a/cmd/lava/internal/run/run.go
+++ b/cmd/lava/internal/run/run.go
@@ -61,10 +61,13 @@ func run(args []string) error {
 		return fmt.Errorf("new writer: %w", err)
 	}
 	defer rw.Close()
+
 	exitCode, err := rw.Write(er)
 	if err != nil {
 		return fmt.Errorf("render report: %w", err)
 	}
+
 	os.Exit(int(exitCode))
+
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -273,10 +273,12 @@ func (f *OutputFormat) UnmarshalYAML(value *yaml.Node) error {
 
 // Exclusion represents the criteria to exclude a given finding.
 type Exclusion struct {
-	// Target is the name of the affected target.
+	// Target is a regular expression that matches the name of the
+	// affected target.
 	Target string `yaml:"target"`
 
-	// Resource is the name of the affected resource.
+	// Resource is a regular expression that matches the name of
+	// the affected resource.
 	Resource string `yaml:"resource"`
 
 	// Fingerprint defines the context in where the vulnerability
@@ -284,7 +286,8 @@ type Exclusion struct {
 	// affected target, the asset type and the checktype options.
 	Fingerprint string `yaml:"fingerprint"`
 
-	// Summary is a short description of the exclusion.
+	// Summary is a regular expression that matches the summary of
+	// the vulnerability.
 	Summary string `yaml:"summary"`
 
 	// Description describes the exclusion.


### PR DESCRIPTION
Fix `config.Exclusion` docs to match the behavior introduced in the
following PR:

- https://github.com/adevinta/lava/pull/10