### PR TITLE
internal/report: print empty array in JSON output if no vulns

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -166,7 +166,7 @@ func (writer Writer) filterVulns(vulns []vulnerability) []vulnerability {
 		return cmp.Compare(b.Severity, a.Severity)
 	})
 
-	var fvulns []vulnerability
+	fvulns := make([]vulnerability, 0)
 	for _, v := range vulns {
 		if v.Severity < writer.minSeverity {
 			break


### PR DESCRIPTION
Before, `jsonPrinter` would print `null` if there are no
vulnerabilities. After this change, it prints `[]`.