### PR TITLE
cmd/lava: add -forcecolor flag to run command

### DIFF
--- a/cmd/lava/internal/run/run.go
+++ b/cmd/lava/internal/run/run.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/fatih/color"
+
 	"github.com/adevinta/lava/cmd/lava/internal/base"
 	"github.com/adevinta/lava/internal/config"
 	"github.com/adevinta/lava/internal/engine"
@@ -17,18 +19,28 @@ import (
 
 // CmdRun represents the run command.
 var CmdRun = &base.Command{
-	UsageLine: "run [-c config.yaml]",
+	UsageLine: "run [flags]",
 	Short:     "run scan",
 	Long: `
 Run a scan using the provided config file.
 
-By default, "lava run" looks for a configuration file with the name
-"lava.yaml" in the current directory. The -c flag allows to specify a
-custom configuration file.
+The -c flag allows to specify a configuration file. By default, "lava
+run" looks for a configuration file with the name "lava.yaml" in the
+current directory.
+
+The -forcecolor flag forces colorized output. By default, colorized
+output is disabled in the following cases:
+
+- Lava is not executed from a terminal.
+- Lava is executed from a "dumb" terminal.
+- The NO_COLOR environment variable is set (regardless of its value).
 	`,
 }
 
-var cfgfile = CmdRun.Flag.String("c", "lava.yaml", "config file")
+var (
+	cfgfile    = CmdRun.Flag.String("c", "lava.yaml", "config file")
+	forceColor = CmdRun.Flag.Bool("forcecolor", false, "force colorized output")
+)
 
 func init() {
 	CmdRun.Run = run // Break initialization cycle.
@@ -38,6 +50,10 @@ func init() {
 func run(args []string) error {
 	if len(args) > 0 {
 		return errors.New("too many arguments")
+	}
+
+	if *forceColor {
+		color.NoColor = false
 	}
 
 	cfg, err := config.ParseFile(*cfgfile)


### PR DESCRIPTION
This PR adds the `-forcecolor` flag to the run command.

The `-forcecolor` flag forces colorized output. By default, colorized
output is disabled in the following cases:

- Lava is not executed from a terminal.
- Lava is executed from a `dumb` terminal.
- The `NO_COLOR` environment variable is set (regardless of its value).

This new flag allows to force colorized output in GitHub Actions.