### PR TITLE
all: collect metrics

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,6 +148,11 @@ type ReportConfig struct {
 	// Exclusions is a list of findings that will be ignored. For
 	// instance, accepted risks, false positives, etc.
 	Exclusions []Exclusion `yaml:"exclusions"`
+
+	// Metrics is the file where the metrics will be written.
+	// If Metrics is an empty string or not specified in the yaml file, then
+	// the metrics report is not saved.
+	Metrics string `yaml:"metrics"`
 }
 
 // Target represents the target of a scan.
@@ -220,7 +225,7 @@ func (s Severity) String() string {
 }
 
 // MarshalText encode a [Severity] as a text.
-func (s *Severity) MarshalText() (text []byte, err error) {
+func (s Severity) MarshalText() (text []byte, err error) {
 	if !s.IsValid() {
 		return nil, ErrInvalidSeverity
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,70 @@
+// Copyright 2023 Adevinta
+
+// Package metrics collects Lava execution metrics.
+package metrics
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+)
+
+// DefaultCollector is the default [Collector].
+var DefaultCollector = NewCollector()
+
+// Collector represents a metrics collector.
+type Collector struct {
+	mutex   sync.Mutex
+	metrics map[string]any
+}
+
+// NewCollector returns a new metrics collector.
+func NewCollector() *Collector {
+	return &Collector{
+		metrics: make(map[string]any),
+	}
+}
+
+// Collect records a metric with the provided name and value.
+func (c *Collector) Collect(name string, value any) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.metrics[name] = value
+}
+
+// Write writes the metrics to the specified [io.Writer].
+func (c *Collector) Write(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(c.metrics); err != nil {
+		return fmt.Errorf("encode JSON: %w", err)
+	}
+	return nil
+}
+
+// Collect records a metric with the provided name and value using
+// [DefaultCollector].
+func Collect(name string, value any) {
+	DefaultCollector.Collect(name, value)
+}
+
+// Write writes the collected metrics to the specified [io.Writer]
+// using [DefaultCollector].
+func Write(w io.Writer) error {
+	return DefaultCollector.Write(w)
+}
+
+// WriteFile writes the collected metrics into the specified file
+// using [DefaultCollector].
+func WriteFile(file string) error {
+	f, err := os.Create(file)
+	if err != nil {
+		return fmt.Errorf("create file: %w", err)
+	}
+	defer f.Close()
+
+	return Write(f)
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,118 @@
+// Copyright 2023 Adevinta
+
+package metrics
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var testdata = []struct {
+	name    string
+	metrics map[string]any
+	want    map[string]any
+}{
+	{
+		name: "happy path",
+		metrics: map[string]any{
+			"metric 1": "metric value 1",
+			"metric 2": 12345,
+			"metric 3": 25.5,
+			"metric 4": map[string]int{
+				"key 1": 1,
+				"key 2": 2,
+			},
+			"metric 5": []string{
+				"one", "two", "three",
+			},
+		},
+		want: map[string]any{
+			"metric 1": "metric value 1",
+			"metric 2": float64(12345),
+			"metric 3": 25.5,
+			"metric 4": map[string]any{
+				"key 1": float64(1),
+				"key 2": float64(2),
+			},
+			"metric 5": []any{
+				"one", "two", "three",
+			},
+		},
+	},
+}
+
+func TestWrite(t *testing.T) {
+	for _, tt := range testdata {
+		t.Run(tt.name, func(t *testing.T) {
+			oldDefaultCollector := DefaultCollector
+			defer func() { DefaultCollector = oldDefaultCollector }()
+
+			DefaultCollector = NewCollector()
+
+			var buf bytes.Buffer
+
+			for key, value := range tt.metrics {
+				Collect(key, value)
+			}
+
+			if err := Write(&buf); err != nil {
+				t.Fatalf("error writing metrics: %v", err)
+			}
+
+			var got map[string]any
+			if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+				t.Errorf("error decoding JSON metrics: %v", err)
+			}
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("metrics mismatch (-want +got):\n%v", diff)
+			}
+		})
+	}
+}
+
+func TestWriteFile(t *testing.T) {
+	for _, tt := range testdata {
+		t.Run(tt.name, func(t *testing.T) {
+			oldDefaultCollector := DefaultCollector
+			defer func() { DefaultCollector = oldDefaultCollector }()
+
+			DefaultCollector = NewCollector()
+
+			tmpPath, err := os.MkdirTemp("", "")
+			if err != nil {
+				t.Fatalf("error creating temp dir: %v", err)
+			}
+			defer os.RemoveAll(tmpPath)
+
+			file := path.Join(tmpPath, "metrics.json")
+
+			for key, value := range tt.metrics {
+				Collect(key, value)
+			}
+
+			if err = WriteFile(file); err != nil {
+				t.Fatalf("error writing metrics: %v", err)
+			}
+
+			data, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatalf("error reading metrics file: %v", err)
+			}
+
+			var got map[string]any
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Errorf("error decoding JSON metrics: %v", err)
+			}
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("metrics mismatch (-want +got):\n%v", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the functionality to gather metrics along the Lava scanning process.
To enable the functionality, you only have to add a key `metrics`, and as value the output file, in the report section of the configuration file and a file will appear when the execution of the scan finishes.
List of collected metrics:
- Lava Version: `lava_version`
- Total amount of excluded vulnerabilities: `excluded`. These vulnerabilities are not included in the count of vulnerabilities per severity.
- Vulnerabilities per severity: `vulnerabilities`
- Targets: `targets`
- Exit Code: `exit_code`
- Execution Time: `execution_time`
- Duration: `duration`