### PR TITLE
cmd/lava: do not change the current working directory on 'lava scan'

### DIFF
--- a/cmd/lava/internal/scan/scan.go
+++ b/cmd/lava/internal/scan/scan.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/fatih/color"
@@ -67,10 +66,6 @@ func run(args []string) error {
 	cfg, err := config.ParseFile(*cfgfile)
 	if err != nil {
 		return fmt.Errorf("parse config file: %w", err)
-	}
-
-	if err = os.Chdir(filepath.Dir(*cfgfile)); err != nil {
-		return fmt.Errorf("change directory: %w", err)
 	}
 
 	metrics.Collect("lava_version", cfg.LavaVersion)

--- a/cmd/lava/internal/scan/scan_test.go
+++ b/cmd/lava/internal/scan/scan_test.go
@@ -70,6 +70,7 @@ func TestRun(t *testing.T) {
 				exitCode = status
 			}
 
+			mustChdir(tmpPath)
 			if err := run(nil); err != nil {
 				t.Fatalf("run error: %v", err)
 			}


### PR DESCRIPTION
This PR modifies the Lava command so it does not change the current
working directory before executing a scan. This makes easier to use
configuration files that are stored in locations different to the one
of the target project.