### PR TITLE
internal: move validation of number of checktypes URLs to config package

### DIFF
--- a/internal/checktype/checktype.go
+++ b/internal/checktype/checktype.go
@@ -15,15 +15,9 @@ import (
 	"github.com/adevinta/lava/internal/urlutil"
 )
 
-var (
-	// ErrMalformedCatalog is returned by [NewCatalog] when the
-	// format of the retrieved catalog is not valid.
-	ErrMalformedCatalog = errors.New("malformed catalog")
-
-	// ErrMissingCatalog is returned by [NewCatalog] when no
-	// catalog URLs are provided.
-	ErrMissingCatalog = errors.New("missing catalog URLs")
-)
+// ErrMalformedCatalog is returned by [NewCatalog] when the format of
+// the retrieved catalog is not valid.
+var ErrMalformedCatalog = errors.New("malformed catalog")
 
 // Checktype represents a Vulcan checktype.
 type Checktype checkcatalog.Checktype
@@ -47,10 +41,6 @@ type Catalog map[string]Checktype
 // indexed by name. If a checktype is duplicated it is overridden with
 // the last one.
 func NewCatalog(urls []string) (Catalog, error) {
-	if len(urls) == 0 {
-		return nil, ErrMissingCatalog
-	}
-
 	checktypes := make(Catalog)
 	for _, url := range urls {
 		data, err := urlutil.Get(url)

--- a/internal/checktype/checktype_test.go
+++ b/internal/checktype/checktype_test.go
@@ -117,12 +117,6 @@ func TestNewCatalog(t *testing.T) {
 			want:    nil,
 			wantErr: ErrMalformedCatalog,
 		},
-		{
-			name:    "empty urls",
-			urls:    []string{},
-			want:    nil,
-			wantErr: ErrMissingCatalog,
-		},
 	}
 
 	for _, tt := range tests {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,10 @@ var (
 	// Specification.
 	ErrInvalidLavaVersion = errors.New("invalid Lava version")
 
+	// ErrNoChecktypesURLs means that no checktypes URLs were
+	// specified.
+	ErrNoChecktypesURLs = errors.New("no checktypes URLs")
+
 	// ErrNoTargets means that no targets were specified.
 	ErrNoTargets = errors.New("no targets")
 
@@ -97,6 +101,11 @@ func (c Config) validate() error {
 	// Lava version validation.
 	if !semver.IsValid(c.LavaVersion) {
 		return ErrInvalidLavaVersion
+	}
+
+	// Checktypes URLs validation.
+	if len(c.ChecktypesURLs) == 0 {
+		return ErrNoChecktypesURLs
 	}
 
 	// Targets validation.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -27,6 +27,9 @@ func TestParse(t *testing.T) {
 			file: "testdata/valid.yaml",
 			want: Config{
 				LavaVersion: "v1.0.0",
+				ChecktypesURLs: []string{
+					"checktypes.json",
+				},
 				Targets: []Target{
 					{
 						Identifier: "example.com",
@@ -46,6 +49,12 @@ func TestParse(t *testing.T) {
 			file:    "testdata/invalid_lava_version.yaml",
 			want:    Config{},
 			wantErr: ErrInvalidLavaVersion,
+		},
+		{
+			name:    "no checktypes URLs",
+			file:    "testdata/no_checktypes_urls.yaml",
+			want:    Config{},
+			wantErr: ErrNoChecktypesURLs,
 		},
 		{
 			name:    "no targets",
@@ -70,6 +79,9 @@ func TestParse(t *testing.T) {
 			file: "testdata/critical_severity.yaml",
 			want: Config{
 				LavaVersion: "v1.0.0",
+				ChecktypesURLs: []string{
+					"checktypes.json",
+				},
 				ReportConfig: ReportConfig{
 					Severity: SeverityCritical,
 				},
@@ -92,6 +104,9 @@ func TestParse(t *testing.T) {
 			file: "testdata/never_pull_policy.yaml",
 			want: Config{
 				LavaVersion: "v1.0.0",
+				ChecktypesURLs: []string{
+					"checktypes.json",
+				},
 				AgentConfig: AgentConfig{
 					PullPolicy: agentconfig.PullPolicyNever,
 				},
@@ -120,6 +135,9 @@ func TestParse(t *testing.T) {
 			file: "testdata/json_output_format.yaml",
 			want: Config{
 				LavaVersion: "v1.0.0",
+				ChecktypesURLs: []string{
+					"checktypes.json",
+				},
 				Targets: []Target{
 					{
 						Identifier: "example.com",
@@ -142,6 +160,9 @@ func TestParse(t *testing.T) {
 			file: "testdata/debug_log_level.yaml",
 			want: Config{
 				LavaVersion: "v1.0.0",
+				ChecktypesURLs: []string{
+					"checktypes.json",
+				},
 				Targets: []Target{
 					{
 						Identifier: "example.com",

--- a/internal/config/testdata/critical_severity.yaml
+++ b/internal/config/testdata/critical_severity.yaml
@@ -1,4 +1,6 @@
 lava: v1.0.0
+checktypesURLs:
+  - checktypes.json
 targets:
   - identifier: example.com
     assetType: DomainName

--- a/internal/config/testdata/debug_log_level.yaml
+++ b/internal/config/testdata/debug_log_level.yaml
@@ -1,4 +1,6 @@
 lava: v1.0.0
+checktypesURLs:
+  - checktypes.json
 targets:
   - identifier: example.com
     assetType: DomainName

--- a/internal/config/testdata/invalid_lava_version.yaml
+++ b/internal/config/testdata/invalid_lava_version.yaml
@@ -1,1 +1,6 @@
 lava: 1.0.0
+checktypesURLs:
+  - checktypes.json
+targets:
+  - identifier: example.com
+    assetType: DomainName

--- a/internal/config/testdata/invalid_log_level.yaml
+++ b/internal/config/testdata/invalid_log_level.yaml
@@ -1,4 +1,6 @@
 lava: v1.0.0
+checktypesURLs:
+  - checktypes.json
 targets:
   - identifier: example.com
     assetType: DomainName

--- a/internal/config/testdata/invalid_output_format.yaml
+++ b/internal/config/testdata/invalid_output_format.yaml
@@ -1,4 +1,6 @@
 lava: v1.0.0
+checktypesURLs:
+  - checktypes.json
 targets:
   - identifier: example.com
     assetType: DomainName

--- a/internal/config/testdata/invalid_pull_policy.yaml
+++ b/internal/config/testdata/invalid_pull_policy.yaml
@@ -1,4 +1,6 @@
 lava: v1.0.0
+checktypesURLs:
+  - checktypes.json
 targets:
   - identifier: example.com
     assetType: DomainName

--- a/internal/config/testdata/invalid_severity.yaml
+++ b/internal/config/testdata/invalid_severity.yaml
@@ -1,4 +1,6 @@
 lava: v1.0.0
+checktypesURLs:
+  - checktypes.json
 targets:
   - identifier: example.com
     assetType: DomainName

--- a/internal/config/testdata/invalid_target_asset_type.yaml
+++ b/internal/config/testdata/invalid_target_asset_type.yaml
@@ -1,4 +1,6 @@
 lava: v1.0.0
+checktypesURLs:
+  - checktypes.json
 targets:
   - identifier: example.com
     assetType: Domain

--- a/internal/config/testdata/json_output_format.yaml
+++ b/internal/config/testdata/json_output_format.yaml
@@ -1,4 +1,6 @@
 lava: v1.0.0
+checktypesURLs:
+  - checktypes.json
 targets:
   - identifier: example.com
     assetType: DomainName

--- a/internal/config/testdata/never_pull_policy.yaml
+++ b/internal/config/testdata/never_pull_policy.yaml
@@ -1,4 +1,6 @@
 lava: v1.0.0
+checktypesURLs:
+  - checktypes.json
 targets:
   - identifier: example.com
     assetType: DomainName

--- a/internal/config/testdata/no_checktypes_urls.yaml
+++ b/internal/config/testdata/no_checktypes_urls.yaml
@@ -1,5 +1,4 @@
 lava: v1.0.0
-checktypesURLs:
-  - checktypes.json
 targets:
   - identifier: example.com
+    assetType: DomainName

--- a/internal/config/testdata/no_target_identifier.yaml
+++ b/internal/config/testdata/no_target_identifier.yaml
@@ -1,3 +1,5 @@
 lava: v1.0.0
+checktypesURLs:
+  - checktypes.json
 targets:
   - assetType: DomainName

--- a/internal/config/testdata/no_targets.yaml
+++ b/internal/config/testdata/no_targets.yaml
@@ -1,2 +1,4 @@
 lava: v1.0.0
+checktypesURLs:
+  - checktypes.json
 targets: []

--- a/internal/config/testdata/valid.yaml
+++ b/internal/config/testdata/valid.yaml
@@ -1,4 +1,6 @@
 lava: v1.0.0
+checktypesURLs:
+  - checktypes.json
 targets:
   - identifier: example.com
     assetType: DomainName


### PR DESCRIPTION
Calling `checktype.NewCatalog` with no URLs should be valid. In that
case, the returned catalog will be empty.

At the same time, we want to force users to provide at least one
catalog URL in the configuration file. Otherwise, no security checks
would be run, which is not an obvious behavior. Thus, this commit
moves this validation to the config package, which also validates that
at least one target is provided.