### PR TITLE
internal/urlutil: fix invalid status code error

### DIFF
--- a/internal/urlutil/urlutil.go
+++ b/internal/urlutil/urlutil.go
@@ -54,7 +54,7 @@ func getHTTP(parsedURL *url.URL) ([]byte, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("get %q: %w", parsedURL, err)
+		return nil, fmt.Errorf("get %q: invalid status code: %v", parsedURL, resp.StatusCode)
 	}
 	return io.ReadAll(resp.Body)
 }


### PR DESCRIPTION
This PR fixes the error returned by `urlutil.getHTTP` when the
specified URL returns a status code different to `200 OK`.

It changes the error from:

```
error: engine run: get checkype catalog: get "https://example.com/checktypes.json": %!w(<nil>)
```

To:

```
error: engine run: get checkype catalog: get "https://example.com/checktypes.json": invalid status code: 404
```