### PR TITLE
internal, cmd/lava: revisit metrics collection

### DIFF
--- a/cmd/lava/internal/scan/scan.go
+++ b/cmd/lava/internal/scan/scan.go
@@ -78,16 +78,19 @@ func run(args []string) error {
 		color.NoColor = false
 	}
 
-	executionTime := time.Now()
-	metrics.Collect("execution_time", executionTime)
+	startTime := time.Now()
+	metrics.Collect("start_time", startTime)
 
 	cfg, err := config.ParseFile(*cfgfile)
 	if err != nil {
 		return fmt.Errorf("parse config file: %w", err)
 	}
 
-	metrics.Collect("lava_version", cfg.LavaVersion)
+	metrics.Collect("config_version", cfg.LavaVersion)
+	metrics.Collect("checktype_urls", cfg.ChecktypeURLs)
 	metrics.Collect("targets", cfg.Targets)
+	metrics.Collect("severity", cfg.ReportConfig.Severity)
+	metrics.Collect("exclusion_count", len(cfg.ReportConfig.Exclusions))
 
 	base.LogLevel.Set(cfg.LogLevel)
 	er, err := engine.Run(cfg.ChecktypeURLs, cfg.Targets, cfg.AgentConfig)
@@ -107,8 +110,7 @@ func run(args []string) error {
 	}
 
 	metrics.Collect("exit_code", exitCode)
-	duration := time.Since(executionTime)
-	metrics.Collect("duration", duration.String())
+	metrics.Collect("duration", time.Since(startTime).Seconds())
 
 	if cfg.ReportConfig.Metrics != "" {
 		if err = metrics.WriteFile(cfg.ReportConfig.Metrics); err != nil {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -25,6 +25,7 @@ import (
 	"github.com/adevinta/lava/internal/checktypes"
 	"github.com/adevinta/lava/internal/config"
 	"github.com/adevinta/lava/internal/dockerutil"
+	"github.com/adevinta/lava/internal/metrics"
 )
 
 // dockerInternalHost is the host used by the containers to access the
@@ -50,6 +51,8 @@ func Run(checktypeURLs []string, targets []config.Target, cfg config.AgentConfig
 	if err != nil {
 		return nil, fmt.Errorf("get checkype catalog: %w", err)
 	}
+
+	metrics.Collect("checktypes", catalog)
 
 	jl, err := generateJobs(catalog, targets)
 	if err != nil {

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -76,8 +76,9 @@ func (writer Writer) Write(er engine.Report) (ExitCode, error) {
 		return 0, fmt.Errorf("calculate summary: %w", err)
 	}
 
-	metrics.Collect("excluded", sum.excluded)
-	metrics.Collect("vulnerabilities", sum.count)
+	metrics.Collect("excluded_vulnerability_count", sum.excluded)
+	metrics.Collect("vulnerability_count", sum.count)
+
 	exitCode := writer.calculateExitCode(sum)
 	fvulns := writer.filterVulns(vulns)
 	if err = writer.prn.Print(writer.w, fvulns, sum); err != nil {


### PR DESCRIPTION
This PR revisits the current metrics collection implemented in Lava. It makes the following changes:

**Rename fields**

- Rename `execution_time` to `start_time`. I think `execution_time` can be confusing as it could refer to when the scan started or what was its duration.
- Rename `lava_version` to `config_version`. There is in fact two different versions: the minimum version required by the config (`config_version`) and the version of the Lava command used to run the scan (`lava_version`). The latter is not used yet, so it will be added in future PRs.
- Rename `excluded` to `excluded_vulnerability_count`. It is true that `excluded_vulnerability_count` is longer but it is also more explicit. `excluded` could be confused with the exclusions present in the config.
- Rename `vulnerabilities` to `vulnerability_count`: `vulnerability_count` is consistent with `excluded_vulnerability_count`. It also frees the name `vulnerabilities` for things related to the details of found vulnerabilities if they are included at some point.

**Add fields**

- `checktype_urls`: This field allows to know how many people is pinning the checktypes catalogs to a specific version, how many people depends on custom/local checktype catalogs and how many people is using a rolling-release catalog.
- `checktypes`: This field allows to know the checktypes that have been run. The `checktypes_urls` field is not enough because it is possible that we don't have access to the specified catalogs (e.g. private services, deleted commits, unknown branches).
- `severity`: This field allows to know the criteria followed by teams in terms of risk acceptance. It can also be combined with the `exit_code` field to know why Lava reported an error.
- `exclusion_count`: This field allows to know the trend in terms of risk acceptance and false positives.

During the review it is important to make sure that none of the fields present in the metrics format reveals sensitive information (e.g. vulnerability details, exclusion details).

In its current state, the following metrics provide information about the found vulnerabilities:

- `vulnerability_count`: number of found vulnerabilities by severity.
- `excluded_vulnerability_count`: number of found vulnerabilities that have been excluded.
- `exclusion_count`: number of exclusion rules.
- `exit_code`: highest severity among all the vulnerabilities that have been found.

However, they do not include specific details. Of course, the `checktypes` and `targets` fields could be used to narrow down the potential type of vulnerabilities.