### PR TITLE
cmd/lava: check config compatibility

### DIFF
--- a/cmd/lava/internal/version/version.go
+++ b/cmd/lava/internal/version/version.go
@@ -1,0 +1,40 @@
+// Copyright 2023 Adevinta
+
+// Package version implements the version command.
+package version
+
+import (
+	"errors"
+	"fmt"
+	"runtime/debug"
+
+	"github.com/adevinta/lava/cmd/lava/internal/base"
+)
+
+// CmdVersion represents the version command.
+var CmdVersion = &base.Command{
+	UsageLine: "version",
+	Short:     "print Lava version",
+	Long: `
+Version prints the version of the Lava command.
+	`,
+}
+
+func init() {
+	CmdVersion.Run = run // Break initialization cycle.
+}
+
+// run is the entry point of the version command.
+func run(args []string) error {
+	if len(args) > 0 {
+		return errors.New("too many arguments")
+	}
+
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return errors.New("could not read build info")
+	}
+
+	fmt.Printf("Lava version %v\n", bi.Main.Version)
+	return nil
+}

--- a/cmd/lava/main.go
+++ b/cmd/lava/main.go
@@ -15,12 +15,14 @@ import (
 	"github.com/adevinta/lava/cmd/lava/internal/help"
 	"github.com/adevinta/lava/cmd/lava/internal/initialize"
 	"github.com/adevinta/lava/cmd/lava/internal/scan"
+	"github.com/adevinta/lava/cmd/lava/internal/version"
 )
 
 func init() {
 	base.Commands = []*base.Command{
 		scan.CmdScan,
 		initialize.CmdInit,
+		version.CmdVersion,
 
 		help.HelpLavaYAML,
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,6 +120,13 @@ func (c Config) validate() error {
 	return nil
 }
 
+// IsCompatible reports whether the configuration is compatible with
+// the specified version. An invalid semantic version string is
+// considered incompatible.
+func (c Config) IsCompatible(v string) bool {
+	return semver.Compare(v, c.LavaVersion) >= 0
+}
+
 // AgentConfig is the configuration passed to the vulcan-agent.
 type AgentConfig struct {
 	// PullPolicy is the pull policy passed to vulcan-agent.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -208,6 +208,55 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestConfig_IsCompatible(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		v    string
+		want bool
+	}{
+		{
+			name: "same version",
+			cfg:  Config{LavaVersion: "v1.0.0"},
+			v:    "v1.0.0",
+			want: true,
+		},
+		{
+			name: "lower version",
+			cfg:  Config{LavaVersion: "v1.1.0"},
+			v:    "1.0.0",
+			want: false,
+		},
+		{
+			name: "higher version",
+			cfg:  Config{LavaVersion: "v1.0.0"},
+			v:    "v1.1.0",
+			want: true,
+		},
+		{
+			name: "pre-release",
+			cfg:  Config{LavaVersion: "v0.0.0"},
+			v:    "v0.0.0-20231216173526-1150d51c5272",
+			want: false,
+		},
+		{
+			name: "invalid version",
+			cfg:  Config{LavaVersion: "v1.0.0"},
+			v:    "invalid",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.IsCompatible(tt.v)
+			if got != tt.want {
+				t.Errorf("unexpected result: %v, minimum required version: %v, v: %v", got, tt.cfg.LavaVersion, tt.v)
+			}
+		})
+	}
+}
+
 func TestSeverity_MarshalText(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -252,6 +301,7 @@ func TestSeverity_MarshalText(t *testing.T) {
 			wantErr:  ErrInvalidSeverity,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.severity.MarshalText()


### PR DESCRIPTION
This PR changes the Lava command to check that the provided
configuration is compatible with the version of the command.

The version of the command is read at runtime using
`debug.ReadBuildInfo`. This approach works with `go install` and
[goreleaser][goreleaser-get-version].


[goreleaser-get-version]: https://goreleaser.com/cookbooks/build-go-modules/#getting-the-version-from-the-module