### PR TITLE
internal/report: print check status, return exit code greater than 0 on check error

### DIFF
--- a/cmd/lava/internal/scan/scan.go
+++ b/cmd/lava/internal/scan/scan.go
@@ -36,23 +36,25 @@ output is disabled in the following cases:
   - Lava is executed from a "dumb" terminal.
   - The NO_COLOR environment variable is set (regardless of its value).
 
-The exit code of the command depends on the highest severity among all
-the vulnerabilities that have been found.
+The exit code of the command depends on the correct execution of the
+security scan and the highest severity among all the vulnerabilities
+that have been found.
 
-  - 104: Critical severity vulnerabilities found
-  - 103: High severity vulnerabilities found
-  - 102: Medium severity vulnerabilities found
-  - 101: Low severity vulnerabilities found
-  - 100: Informational vulnerabilities found
-  -   2: Syntax error
-  -   1: Command error
   -   0: No vulnerabilities found
+  -   1: Command error
+  -   2: Syntax error
+  -   3: Check error
+  - 100: Informational vulnerabilities found
+  - 101: Low severity vulnerabilities found
+  - 102: Medium severity vulnerabilities found
+  - 103: High severity vulnerabilities found
+  - 104: Critical severity vulnerabilities found
 
 Those vulnerabilities that has been excluded in the configuration are
 not considered in the computation of the exit code. In other words,
 vulnerabilities with a severity that is lower than "report.severity"
-and vulnerabilities that match any "report.exclusions" rules are
-ignored.
+and vulnerabilities that match one or more "report.exclusions" rules
+are ignored.
 	`,
 }
 

--- a/internal/report/human.tmpl
+++ b/internal/report/human.tmpl
@@ -1,5 +1,10 @@
 {{- /* report is the template used to render the full scan report. */ -}}
 {{- define "report" -}}
+{{- if .Status -}}
+{{"STATUS" | bold | underline}}
+{{template "status" .}}
+
+{{end -}}
 {{"SUMMARY" | bold | underline}}
 {{if .Total}}
 {{template "summary" .}}
@@ -9,6 +14,20 @@ No vulnerabilities found during the scan.
 {{- if .Vulns}}
 {{template "vulns" . -}}
 {{end -}}
+{{- end -}}
+
+
+{{- /* status is the template used to render all the check status. */ -}}
+{{- define "status" -}}
+{{range .Status}}
+{{template "checkStatus" . -}}
+{{end}}
+{{- end -}}
+
+
+{{- /* checkStatus is the template used to render one check status. */ -}}
+{{- define "checkStatus" -}}
+- {{.Checktype | bold}} → {{.Target|bold}}: {{.Status}}
 {{- end -}}
 
 

--- a/internal/report/humanprinter.go
+++ b/internal/report/humanprinter.go
@@ -18,7 +18,7 @@ import (
 type humanPrinter struct{}
 
 var (
-	//go:embed templates/human.tmpl
+	//go:embed human.tmpl
 	humanReport string
 
 	// humanTmplFuncs stores the functions called from the
@@ -40,7 +40,7 @@ var (
 )
 
 // Print renders the scan results in a human-readable format.
-func (prn humanPrinter) Print(w io.Writer, vulns []vulnerability, sum summary) error {
+func (prn humanPrinter) Print(w io.Writer, vulns []vulnerability, sum summary, status []checkStatus) error {
 	// count the total non-excluded vulnerabilities found.
 	var total int
 	for _, ss := range sum.count {
@@ -57,11 +57,13 @@ func (prn humanPrinter) Print(w io.Writer, vulns []vulnerability, sum summary) e
 		Total    int
 		Excluded int
 		Vulns    []vulnerability
+		Status   []checkStatus
 	}{
 		Stats:    stats,
 		Total:    total,
 		Excluded: sum.excluded,
 		Vulns:    vulns,
+		Status:   status,
 	}
 
 	if err := humanTmpl.Execute(w, data); err != nil {

--- a/internal/report/humanprinter.go
+++ b/internal/report/humanprinter.go
@@ -40,16 +40,16 @@ var (
 )
 
 // Print renders the scan results in a human-readable format.
-func (prn humanPrinter) Print(w io.Writer, vulns []vulnerability, sum summary, status []checkStatus) error {
+func (prn humanPrinter) Print(w io.Writer, vulns []vulnerability, summ summary, status []checkStatus) error {
 	// count the total non-excluded vulnerabilities found.
 	var total int
-	for _, ss := range sum.count {
+	for _, ss := range summ.count {
 		total += ss
 	}
 
 	stats := make(map[string]int)
 	for s := config.SeverityCritical; s >= config.SeverityInfo; s-- {
-		stats[s.String()] = sum.count[s]
+		stats[s.String()] = summ.count[s]
 	}
 
 	data := struct {
@@ -61,7 +61,7 @@ func (prn humanPrinter) Print(w io.Writer, vulns []vulnerability, sum summary, s
 	}{
 		Stats:    stats,
 		Total:    total,
-		Excluded: sum.excluded,
+		Excluded: summ.excluded,
 		Vulns:    vulns,
 		Status:   status,
 	}

--- a/internal/report/humanprinter_test.go
+++ b/internal/report/humanprinter_test.go
@@ -16,7 +16,7 @@ func TestUserFriendlyPrinter_Print(t *testing.T) {
 	tests := []struct {
 		name            string
 		vulnerabilities []vulnerability
-		sum             summary
+		summ            summary
 		status          []checkStatus
 		want            []string
 	}{
@@ -148,7 +148,7 @@ func TestUserFriendlyPrinter_Print(t *testing.T) {
 					},
 				},
 			},
-			sum: summary{
+			summ: summary{
 				count: map[config.Severity]int{
 					config.SeverityHigh:   3,
 					config.SeverityMedium: 15,
@@ -193,7 +193,7 @@ func TestUserFriendlyPrinter_Print(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			w := humanPrinter{}
-			if err := w.Print(&buf, tt.vulnerabilities, tt.sum, tt.status); err != nil {
+			if err := w.Print(&buf, tt.vulnerabilities, tt.summ, tt.status); err != nil {
 				t.Errorf("unexpected error value: %v", err)
 			}
 			text := buf.String()

--- a/internal/report/humanprinter_test.go
+++ b/internal/report/humanprinter_test.go
@@ -17,6 +17,7 @@ func TestUserFriendlyPrinter_Print(t *testing.T) {
 		name            string
 		vulnerabilities []vulnerability
 		sum             summary
+		status          []checkStatus
 		want            []string
 	}{
 		{
@@ -154,7 +155,16 @@ func TestUserFriendlyPrinter_Print(t *testing.T) {
 				},
 				excluded: 3,
 			},
+			status: []checkStatus{
+				{
+					Checktype: "Check1",
+					Target:    ".",
+					Status:    "FINISHED",
+				},
+			},
 			want: []string{
+				"STATUS",
+				"FINISHED",
 				"SUMMARY",
 				"Number of excluded vulnerabilities not included in the summary table: 3",
 				"VULNERABILITIES",
@@ -164,7 +174,17 @@ func TestUserFriendlyPrinter_Print(t *testing.T) {
 		{
 			name:            "No vulnerabilities",
 			vulnerabilities: nil,
+			status: []checkStatus{
+				{
+					Checktype: "Check1",
+					Target:    ".",
+					Status:    "FINISHED",
+				},
+			},
 			want: []string{
+				"STATUS",
+				"FINISHED",
+				"SUMMARY",
 				"No vulnerabilities found during the scan.",
 			},
 		},
@@ -173,7 +193,7 @@ func TestUserFriendlyPrinter_Print(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			w := humanPrinter{}
-			if err := w.Print(&buf, tt.vulnerabilities, tt.sum); err != nil {
+			if err := w.Print(&buf, tt.vulnerabilities, tt.sum, tt.status); err != nil {
 				t.Errorf("unexpected error value: %v", err)
 			}
 			text := buf.String()

--- a/internal/report/jsonprinter.go
+++ b/internal/report/jsonprinter.go
@@ -12,7 +12,7 @@ import (
 type jsonPrinter struct{}
 
 // Print renders the scan results in JSON format.
-func (prn jsonPrinter) Print(w io.Writer, vulns []vulnerability, _ summary) error {
+func (prn jsonPrinter) Print(w io.Writer, vulns []vulnerability, _ summary, _ []checkStatus) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(vulns); err != nil {

--- a/internal/report/jsonprinter_test.go
+++ b/internal/report/jsonprinter_test.go
@@ -163,7 +163,7 @@ func TestJsonPrinter_Print(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			w := jsonPrinter{}
-			err := w.Print(&buf, tt.vulnerabilities, summary{})
+			err := w.Print(&buf, tt.vulnerabilities, summary{}, nil)
 			if (err == nil) != tt.wantNilErr {
 				t.Errorf("unexpected error value: %v", err)
 			}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -19,14 +19,14 @@ import (
 func TestWriter_calculateExitCode(t *testing.T) {
 	tests := []struct {
 		name    string
-		sum     summary
+		summ    summary
 		status  []checkStatus
 		rConfig config.ReportConfig
 		want    ExitCode
 	}{
 		{
 			name: "critical",
-			sum: summary{
+			summ: summary{
 				count: map[config.Severity]int{
 					config.SeverityCritical: 1,
 					config.SeverityHigh:     1,
@@ -49,7 +49,7 @@ func TestWriter_calculateExitCode(t *testing.T) {
 		},
 		{
 			name: "high",
-			sum: summary{
+			summ: summary{
 				count: map[config.Severity]int{
 					config.SeverityCritical: 0,
 					config.SeverityHigh:     1,
@@ -72,7 +72,7 @@ func TestWriter_calculateExitCode(t *testing.T) {
 		},
 		{
 			name: "medium",
-			sum: summary{
+			summ: summary{
 				count: map[config.Severity]int{
 					config.SeverityCritical: 0,
 					config.SeverityHigh:     0,
@@ -95,7 +95,7 @@ func TestWriter_calculateExitCode(t *testing.T) {
 		},
 		{
 			name: "low",
-			sum: summary{
+			summ: summary{
 				count: map[config.Severity]int{
 					config.SeverityCritical: 0,
 					config.SeverityHigh:     0,
@@ -118,7 +118,7 @@ func TestWriter_calculateExitCode(t *testing.T) {
 		},
 		{
 			name: "info",
-			sum: summary{
+			summ: summary{
 				count: map[config.Severity]int{
 					config.SeverityCritical: 0,
 					config.SeverityHigh:     0,
@@ -141,7 +141,7 @@ func TestWriter_calculateExitCode(t *testing.T) {
 		},
 		{
 			name: "zero exit code",
-			sum: summary{
+			summ: summary{
 				count: map[config.Severity]int{
 					config.SeverityCritical: 0,
 					config.SeverityHigh:     0,
@@ -165,7 +165,7 @@ func TestWriter_calculateExitCode(t *testing.T) {
 		},
 		{
 			name: "failed check",
-			sum: summary{
+			summ: summary{
 				count: map[config.Severity]int{
 					config.SeverityCritical: 0,
 					config.SeverityHigh:     0,
@@ -188,7 +188,7 @@ func TestWriter_calculateExitCode(t *testing.T) {
 		},
 		{
 			name: "inconclusive check",
-			sum: summary{
+			summ: summary{
 				count: map[config.Severity]int{
 					config.SeverityCritical: 0,
 					config.SeverityHigh:     0,
@@ -216,7 +216,7 @@ func TestWriter_calculateExitCode(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unable to create a report writer: %v", err)
 			}
-			got := w.calculateExitCode(tt.sum, tt.status)
+			got := w.calculateExitCode(tt.summ, tt.status)
 			if got != tt.want {
 				t.Errorf("unexpected exit code: got: %v, want: %v", got, tt.want)
 			}


### PR DESCRIPTION
This PR print the status of every check as part of the human-readable
report. It also makes Lava to exit with code greater than 0 if any
check has failed.

I also took the opportunity to rename `sum` variables to `summ`, which
I feel is a more obvious abbreviation of summary.