### PR TITLE
.golangci.yaml: allow any year in the headers

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,8 +18,10 @@ linters-settings:
     values:
       const:
         COMPANY: Adevinta
+      regexp:
+        ANY-YEAR: \d{4}
     template: |-
-      Copyright {{ YEAR }} {{ COMPANY }}
+      Copyright {{ ANY-YEAR }} {{ COMPANY }}
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0


### PR DESCRIPTION
Allow any year in the headers.
With this change we avoid errors when we update files created in previous years.
