### PR TITLE
cmd/lava: remove Adevinta copyright from 'lava init' output

### DIFF
--- a/cmd/lava/internal/initialize/default.yaml
+++ b/cmd/lava/internal/initialize/default.yaml
@@ -1,5 +1,3 @@
-# Copyright 2023 Adevinta
-
 lava: v0.0.0
 checktypes:
   - https://github.com/adevinta/lava-resources/releases/download/checktypes/v0/checktypes.json


### PR DESCRIPTION
This PR removes the Adevinta copyright disclaimer from the yaml file
generated by `lava init`. This command is run by end-users to generate
an initial lava.yaml, so this file should not include such disclaimer.