### PR TITLE
cmd/lava: use 'Path' as default target in 'lava init' output

### DIFF
--- a/cmd/lava/internal/initialize/default.yaml
+++ b/cmd/lava/internal/initialize/default.yaml
@@ -3,7 +3,7 @@ checktypes:
   - https://github.com/adevinta/lava-resources/releases/download/checktypes/v0/checktypes.json
 targets:
   - identifier: .
-    type: GitRepository
+    type: Path
 agent:
   parallel: 4
 report:


### PR DESCRIPTION
This PR changes the asset type of the default target created by
`lava init` from `GitRepository` to `Path`. `GitRepository` only
allows paths corresponding to Git repositories, whereas `Path` allows
any path. Thus, `Path` seems more sensible for the default target.