### PR TITLE
internal/config: validate config file schema

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,8 +75,14 @@ type Config struct {
 
 // Parse returns a parsed Lava configuration given an [io.Reader].
 func Parse(r io.Reader) (Config, error) {
+	dec := yaml.NewDecoder(r)
+
+	// Ensure that the keys in the read data exist as fields in
+	// the struct being decoded into.
+	dec.KnownFields(true)
+
 	var cfg Config
-	if err := yaml.NewDecoder(r).Decode(&cfg); err != nil {
+	if err := dec.Decode(&cfg); err != nil {
 		return Config{}, fmt.Errorf("decode config: %w", err)
 	}
 	if err := cfg.validate(); err != nil {

--- a/internal/config/testdata/invalid_lava_version.yaml
+++ b/internal/config/testdata/invalid_lava_version.yaml
@@ -3,4 +3,4 @@ checktypes:
   - checktypes.json
 targets:
   - identifier: example.com
-    assetType: DomainName
+    type: DomainName

--- a/internal/config/testdata/no_checktypes_urls.yaml
+++ b/internal/config/testdata/no_checktypes_urls.yaml
@@ -1,4 +1,4 @@
 lava: v1.0.0
 targets:
   - identifier: example.com
-    assetType: DomainName
+    type: DomainName


### PR DESCRIPTION
This PR ensures that the keys in the configuration file exist as
fields in the struct being decoded into.