### PR TITLE
cmd/lava: force colorized output via environment variable

### DIFF
--- a/cmd/lava/internal/help/helpdoc.go
+++ b/cmd/lava/internal/help/helpdoc.go
@@ -261,6 +261,13 @@ The lava command consults environment variables for configuration. If
 an environment variable is unset or empty, the lava command uses a
 sensible default setting.
 
+General-purpose environment variables:
+
+	LAVA_FORCECOLOR
+		Forces colorized output. By default, colorized output
+		is disabled if the lava command is not executed from a
+		terminal, it is executed from a "dumb" terminal or the
+		NO_COLOR environment variable is set.
 	LAVA_RUNTIME
 		Controls the container runtime used by the lava
 		command. Valid values are "Dockerd" and

--- a/cmd/lava/internal/scan/scan.go
+++ b/cmd/lava/internal/scan/scan.go
@@ -10,8 +10,6 @@ import (
 	"runtime/debug"
 	"time"
 
-	"github.com/fatih/color"
-
 	"github.com/adevinta/lava/cmd/lava/internal/base"
 	"github.com/adevinta/lava/internal/config"
 	"github.com/adevinta/lava/internal/engine"
@@ -29,13 +27,6 @@ Run a scan using the provided config file.
 The -c flag allows to specify a configuration file. By default, "lava
 scan" looks for a configuration file with the name "lava.yaml" in the
 current directory.
-
-The -forcecolor flag forces colorized output. By default, colorized
-output is disabled in the following cases:
-
-  - Lava is not executed from a terminal.
-  - Lava is executed from a "dumb" terminal.
-  - The NO_COLOR environment variable is set (regardless of its value).
 
 The exit code of the command depends on the correct execution of the
 security scan and the highest severity among all the vulnerabilities
@@ -59,10 +50,7 @@ are ignored.
 	`,
 }
 
-var (
-	cfgfile    = CmdScan.Flag.String("c", "lava.yaml", "config file")
-	forceColor = CmdScan.Flag.Bool("forcecolor", false, "force colorized output")
-)
+var cfgfile = CmdScan.Flag.String("c", "lava.yaml", "config file")
 
 func init() {
 	CmdScan.Run = run // Break initialization cycle.
@@ -91,10 +79,6 @@ func run(args []string) error {
 func scan(args []string) (int, error) {
 	if len(args) > 0 {
 		return 0, errors.New("too many arguments")
-	}
-
-	if *forceColor {
-		color.NoColor = false
 	}
 
 	startTime := time.Now()

--- a/cmd/lava/main.go
+++ b/cmd/lava/main.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 
+	"github.com/fatih/color"
 	"github.com/jroimartin/clilog"
 
 	"github.com/adevinta/lava/cmd/lava/internal/base"
@@ -43,6 +45,11 @@ func main() {
 		os.Exit(2)
 	}
 
+	if err := parseEnv(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
+	}
+
 	if args[0] == "help" {
 		help.Help(args[1:])
 		return
@@ -66,4 +73,15 @@ func main() {
 
 	fmt.Fprintf(os.Stderr, "Unknown command %q. Run 'lava help'.\n", args[0])
 	os.Exit(2)
+}
+
+func parseEnv() error {
+	if envForceColor := os.Getenv("LAVA_FORCECOLOR"); envForceColor != "" {
+		forceColor, err := strconv.ParseBool(envForceColor)
+		if err != nil {
+			return fmt.Errorf("invalid LAVA_FORCECOLOR value: %v", envForceColor)
+		}
+		color.NoColor = !forceColor
+	}
+	return nil
 }


### PR DESCRIPTION
Colorized output depends on the environment where lava is
executed. Thus, an environment variable seems a better fit for this
configuration. Otherwise, every lava command that outputs colors would
require a `-forcecolor` flag.