### PR TITLE
cmd/lava: fix inconsistencies and style issues in builtin help

### DIFF
--- a/cmd/lava/internal/base/base.go
+++ b/cmd/lava/internal/base/base.go
@@ -41,6 +41,6 @@ func (c *Command) Name() string {
 // Usage prints a usage message documenting the command.
 func (c *Command) Usage() {
 	fmt.Fprintf(os.Stderr, "usage: %s\n", c.UsageLine)
-	fmt.Fprintf(os.Stderr, "Run 'lava help %s' for details.\n", c.Name())
+	fmt.Fprintf(os.Stderr, "Run \"lava help %s\" for details.\n", c.Name())
 	os.Exit(2)
 }

--- a/cmd/lava/internal/help/help.go
+++ b/cmd/lava/internal/help/help.go
@@ -32,7 +32,7 @@ func Help(args []string) {
 		}
 	}
 
-	fmt.Fprintf(os.Stderr, "Unknown help topic %q. Run 'lava help'.\n", arg)
+	fmt.Fprintf(os.Stderr, "Unknown help topic %q. Run \"lava help\".\n", arg)
 	os.Exit(2)
 }
 
@@ -51,7 +51,8 @@ func tmpl(text string, data interface{}) {
 	}
 }
 
-const usageTemplate = `Lava runs Vulcan checks locally
+const usageTemplate = `Lava is a tool for running security checks in your local and CI/CD
+environments.
 
 Usage:
 
@@ -61,13 +62,13 @@ The commands are:
 {{range .}}{{ if .Run}}
 	{{.Name | printf "%-11s"}} {{.Short}}{{end}}{{end}}
 
-Use 'lava help <command>' for more information about a command.
+Use "lava help <command>" for more information about a command.
 
 Additional help topics:
 {{range .}}{{if not .Run}}
 	{{.Name | printf "%-11s"}} {{.Short}}{{end}}{{end}}
 
-Use 'lava help <topic>' for more information about that topic.
+Use "lava help <topic>" for more information about that topic.
 `
 
 const helpTemplate = `{{if .Run}}usage: lava {{.UsageLine}}

--- a/cmd/lava/internal/help/helpdoc.go
+++ b/cmd/lava/internal/help/helpdoc.go
@@ -137,7 +137,7 @@ the following properties.
   - output: path of the output file. If not specified, stdout is used.
   - metrics: path of the file where the metrics report will be
     written. If not specified, then the metrics report is not
-    generated. For more details, use 'lava help metrics'.
+    generated. For more details, use "lava help metrics".
   - exclusions: list of rules that define what findings should be
     excluded from the report. It allows to ignore findings because of
     accepted risks, false positives, etc.
@@ -191,8 +191,8 @@ After a security scan has finished, Lava can generate a metrics file
 with security, operational and configuration information. This data is
 serialized as JSON.
 
-For more details about how to enable this functionality, use 'lava
-help lava.yaml'.
+For more details about how to enable this functionality, use "lava
+help lava.yaml".
 
 # Example
 

--- a/cmd/lava/internal/scan/scan.go
+++ b/cmd/lava/internal/scan/scan.go
@@ -47,6 +47,10 @@ not considered in the computation of the exit code. In other words,
 vulnerabilities with a severity that is lower than "report.severity"
 and vulnerabilities that match one or more "report.exclusions" rules
 are ignored.
+
+Lava supports several container runtimes. The environment variable
+LAVA_RUNTIME allows to select which one is in use. For more details,
+use "lava help environment".
 	`,
 }
 

--- a/cmd/lava/main.go
+++ b/cmd/lava/main.go
@@ -1,6 +1,7 @@
 // Copyright 2023 Adevinta
 
-// Lava runs security checks locally.
+// Lava is a tool for running security checks in your local and CI/CD
+// environments.
 package main
 
 import (
@@ -71,7 +72,7 @@ func main() {
 		}
 	}
 
-	fmt.Fprintf(os.Stderr, "Unknown command %q. Run 'lava help'.\n", args[0])
+	fmt.Fprintf(os.Stderr, "Unknown command %q. Run \"lava help\".\n", args[0])
 	os.Exit(2)
 }
 


### PR DESCRIPTION
This pull request fixes inconsistencies and style issues in the
builtin help. For instance, the description of the lava command is now
closer to the one in the README file. It also adds a reference to the
environment variable `LAVA_RUNTIME` in `lava help scan`. So, it is
easier to discover it.