### PR TITLE
cmd/lava: use v0.0.0 for the lava.yaml examples in the documentation

### DIFF
--- a/cmd/lava/internal/help/helpdoc.go
+++ b/cmd/lava/internal/help/helpdoc.go
@@ -271,7 +271,7 @@ General-purpose environment variables:
 	LAVA_RUNTIME
 		Controls the container runtime used by the lava
 		command. Valid values are "Dockerd" and
-		DockerdDockerDesktop". If not specified, "Dockerd" is
+		"DockerdDockerDesktop". If not specified, "Dockerd" is
 		used. The values "DockerdRancherDesktop" and
 		"DockerdPodmanDesktop" are also valid, but they are
 		considered experimental.

--- a/cmd/lava/internal/help/helpdoc.go
+++ b/cmd/lava/internal/help/helpdoc.go
@@ -17,7 +17,7 @@ lava.yaml) that defines the parameters of the security scan.
 A Lava configuration file is a YAML document as shown in the following
 example.
 
-	lava: v1.0.0
+	lava: v0.0.0
 	checktypes:
 	  - checktypes.json
 	targets:
@@ -42,7 +42,7 @@ This help topic describes every configuration parameter in detail.
 The "lava" field describes the minimum required version of the Lava
 command. For instance,
 
-	lava: v1.0.0
+	lava: v0.0.0
 
 Using a Lava command whose version is lower than the minimum version
 required by the configuration file returns an error.


### PR DESCRIPTION
The `lava.yaml` examples in documentation specify `lava: v1.0.0`,
which is higher than the latest Lava version (v0.4.1). This makes Lava
to exit with error in the case of using the examples as a starting
point. The examples use v1.0.0 because that will be the first Lava
stable release. However, it is true that right now it is misleading.

This PR updates the documentation to specify v0.0.0. This will be
changed again before releasing Lava v1.0.0.