### PR TITLE
cmd/lava: record Lava command version in metrics file

### DIFF
--- a/cmd/lava/internal/help/helpdoc.go
+++ b/cmd/lava/internal/help/helpdoc.go
@@ -211,6 +211,7 @@ example.
 	      "assets": ["GitRepository"]
 	    }
 	  },
+	  "lava_version": "v0.4.2",
 	  "config_version": "v0.0.0",
 	  "duration": 10.986237086,
 	  "excluded_vulnerability_count": 3,
@@ -237,6 +238,7 @@ A Lava metrics file contains the following data:
   - checktype_urls: List of URLs pointing to checktype catalogs.
   - checktypes: Checktype catalog used during the scan. It is computed
     by merging all the checktype catalogs specified in checktype_urls.
+  - lava_version: Version of the Lava command.
   - config_version: Minimum version of Lava required by the
     configuration file.
   - duration: Duration of the scan.

--- a/cmd/lava/internal/scan/scan.go
+++ b/cmd/lava/internal/scan/scan.go
@@ -103,6 +103,7 @@ func scan(args []string) (int, error) {
 		return 0, fmt.Errorf("minimum required version %v", cfg.LavaVersion)
 	}
 
+	metrics.Collect("lava_version", bi.Main.Version)
 	metrics.Collect("config_version", cfg.LavaVersion)
 	metrics.Collect("checktype_urls", cfg.ChecktypeURLs)
 	metrics.Collect("targets", cfg.Targets)


### PR DESCRIPTION
This PR adds a field with the version of the Lava command to the
metrics file. This allows to track adoption and fragmentation.