### PR TITLE
internal/config: add support for env variables

### DIFF
--- a/cmd/lava/internal/help/helpdoc.go
+++ b/cmd/lava/internal/help/helpdoc.go
@@ -12,6 +12,9 @@ var HelpLavaYAML = &base.Command{
 Each Lava project is defined by a configuration file (usually named
 lava.yaml) that defines the parameters of the security scan.
 
+A Lava configuration file is a YAML document that supports environment
+variable substitution with ${ENVVAR_NAME} notation.
+
 # Example
 
 A Lava configuration file is a YAML document as shown in the following
@@ -23,7 +26,7 @@ example.
 	targets:
 	  - identifier: .
 	    type: GitRepository
-	  - identifier: image
+	  - identifier: ${DOCKER_IMAGE}
 	    type: DockerImage
 	agent:
 	  parallel: 4
@@ -117,7 +120,7 @@ The sample below is a full agent configuration:
 	  registries:
 	    - server: example.com
 	      username: user
-	      password: p4ssw0rd
+	      password: ${REGISTRY_PASSWORD}
 
 It is important to note that Lava is able to use the credentials from
 the container runtime CLIs installed in the system. So, if these CLIs

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,6 +18,7 @@ func TestParse(t *testing.T) {
 	tests := []struct {
 		name          string
 		file          string
+		envs          map[string]string
 		want          Config
 		wantErr       error
 		wantErrRegexp *regexp.Regexp
@@ -33,6 +34,42 @@ func TestParse(t *testing.T) {
 				Targets: []Target{
 					{
 						Identifier: "example.com",
+						AssetType:  types.DomainName,
+					},
+				},
+			},
+		},
+		{
+			name: "valid env",
+			file: "testdata/valid_env.yaml",
+			want: Config{
+				LavaVersion: "v1.0.0",
+				ChecktypeURLs: []string{
+					"checktypes.json",
+				},
+				Targets: []Target{
+					{
+						Identifier: "example.com",
+						AssetType:  types.DomainName,
+					},
+				},
+			},
+			envs: map[string]string{
+				"TARGET":           "example.com",
+				"CHECK_types_URL1": "checktypes.json",
+			},
+		},
+		{
+			name: "invalid env",
+			file: "testdata/invalid_env.yaml",
+			want: Config{
+				LavaVersion: "v1.0.0",
+				ChecktypeURLs: []string{
+					"checktypes.json",
+				},
+				Targets: []Target{
+					{
+						Identifier: "${1NVALID}",
 						AssetType:  types.DomainName,
 					},
 				},
@@ -182,6 +219,9 @@ func TestParse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envs {
+				t.Setenv(k, v)
+			}
 			got, err := ParseFile(tt.file)
 
 			switch {

--- a/internal/config/testdata/invalid_env.yaml
+++ b/internal/config/testdata/invalid_env.yaml
@@ -1,0 +1,6 @@
+lava: v1.0.0
+checktypes:
+  - checktypes.json
+targets:
+  - identifier: ${1NVALID}
+    type: DomainName

--- a/internal/config/testdata/valid_env.yaml
+++ b/internal/config/testdata/valid_env.yaml
@@ -1,0 +1,6 @@
+lava: v1.0.0
+checktypes:
+  - "${CHECK_types_URL1}"
+targets:
+  - identifier: ${TARGET}
+    type: DomainName


### PR DESCRIPTION
This pr allows to reference env variables in the config file.
The format must be `\$\{[a-zA-Z_][a-zA-Z_0-9]*\}`  (i.e.  `${MY_ENV1}`).