### PR TITLE
internal/engine: make target server ignore unsupported asset types

### DIFF
--- a/internal/engine/targetserver.go
+++ b/internal/engine/targetserver.go
@@ -143,8 +143,13 @@ func (srv *targetServer) Handle(key string, target config.Target) (targetMap, er
 		tm, err = srv.handleGitRepo(target)
 	case assettypes.Path:
 		tm, err = srv.handlePath(target)
-	default:
+	case types.IP, types.Hostname, types.WebAddress:
 		tm, err = srv.handle(target)
+	case types.AWSAccount, types.DockerImage, types.IPRange, types.DomainName:
+		// These asset types are not handled by the target
+		// server.
+	default:
+		return targetMap{}, fmt.Errorf("unsupported asset type: %v", target.AssetType)
 	}
 	if err != nil {
 		return targetMap{}, err


### PR DESCRIPTION
Lava currently reports a warning message when a target cannot be
handled by the engine's target server:

	2024-04-28T11:55:40+02:00 WARN could not handle target
	target={alpine:latest DockerImage map[]} err=generate stream:
	get target addr: invalid asset type: DockerImage

In some cases, for instance when the target is a DockerImage, this is
expected. However, it can be misleading for users that do not know the
Lava internal details. Thus, this commit makes the target server
explicitly handle supported asset types.