### PR TITLE
.github/workflows: update golangci-lint to v1.57.2

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     env:
-      GOLANGCI_LINT_VERSION: v1.54.2
+      GOLANGCI_LINT_VERSION: v1.57.2
       GOLANGCI_LINT_OUT_FORMAT: ${{ github.event_name == 'pull_request' && 'github-actions' || 'colored-line-number' }}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This commit updates golangci-lint to v1.57.2.