### PR TITLE
cmd/lava: show usage line as code block in "lava help"

### DIFF
--- a/cmd/lava/internal/help/help.go
+++ b/cmd/lava/internal/help/help.go
@@ -72,7 +72,9 @@ Additional help topics:
 Use "lava help <topic>" for more information about that topic.
 `
 
-const helpTemplate = `{{if .Run}}usage: lava {{.UsageLine}}
+const helpTemplate = `{{if .Run}}Usage:
+
+	lava {{.UsageLine}}
 
 {{end}}{{.Long | trim}}
 `


### PR DESCRIPTION
This PR makes the help topics more pleasant to read to read both in
the CLI and the online docs.

Before:

![image](https://github.com/adevinta/lava/assets/1223476/044a73e5-0ad7-47d7-aaf4-73959843f5fe)

After:

![image](https://github.com/adevinta/lava/assets/1223476/d22d7ca6-db27-4612-ad40-46fceed5e81e)