### PR TITLE
cmd/lava/internal/run: do not remove Docker image if the ID has not changed

### DIFF
--- a/cmd/lava/internal/run/run.go
+++ b/cmd/lava/internal/run/run.go
@@ -314,7 +314,8 @@ func buildChecktype(path string) (string, error) {
 
 	slog.Info("building Docker image", "ref", ref)
 
-	if err := cli.ImageBuild(context.Background(), path, "Dockerfile", ref); err != nil {
+	newID, err := cli.ImageBuild(context.Background(), path, "Dockerfile", ref)
+	if err != nil {
 		return "", fmt.Errorf("image build: %w", err)
 	}
 
@@ -322,6 +323,11 @@ func buildChecktype(path string) (string, error) {
 	case 0:
 		// No image found. Nothing to do.
 	case 1:
+		if newID == summ[0].ID {
+			// The new image has the same ID. So, do not
+			// delete it.
+			break
+		}
 		rmOpts := image.RemoveOptions{Force: true, PruneChildren: true}
 		if _, err := cli.ImageRemove(context.Background(), summ[0].ID, rmOpts); err != nil {
 			return "", fmt.Errorf("image remove: %w", err)

--- a/cmd/lava/internal/run/run.go
+++ b/cmd/lava/internal/run/run.go
@@ -70,7 +70,7 @@ The -pull flag determines the pull policy for container images. Valid
 values are "Always" (always download the image), "IfNotPresent" (pull
 the image if it not present in the local cache) and "Never" (never
 pull the image). If not specified, "IfNotPresent" is used. If the
-checktype is a path, "Always" is not allowed.
+checktype is a path, only "IfNotPresent" and "Never" are allowed.
 
 The -registry flag specifies the container registry. If the registry
 requires authentication, the credentials are provided using the -user
@@ -246,8 +246,8 @@ func engineRun(targetIdent string, checktype string) (engine.Report, error) {
 	case err != nil && !errors.Is(err, fs.ErrNotExist):
 		return nil, err
 	case err == nil && info.IsDir():
-		if agentConfig.PullPolicy == agentconfig.PullPolicyAlways {
-			return nil, errors.New("path checktypes do not allow Always pull policy")
+		if agentConfig.PullPolicy != agentconfig.PullPolicyIfNotPresent && agentConfig.PullPolicy != agentconfig.PullPolicyNever {
+			return nil, errors.New("path checktypes only allow IfNotPresent and Never pull policies")
 		}
 
 		ct, err := buildChecktype(checktype)

--- a/cmd/lava/internal/run/testdata/lava-run-test/.dockerignore
+++ b/cmd/lava/internal/run/testdata/lava-run-test/.dockerignore
@@ -1,0 +1,1 @@
+output.txt

--- a/internal/containers/containers_test.go
+++ b/internal/containers/containers_test.go
@@ -542,7 +542,8 @@ func TestDockerdClient_ImageBuild(t *testing.T) {
 
 	const imgRef = "lava-internal-containers-test:go-test"
 
-	if err := cli.ImageBuild(context.Background(), "testdata/image", "Dockerfile", imgRef); err != nil {
+	imgID, err := cli.ImageBuild(context.Background(), "testdata/image", "Dockerfile", imgRef)
+	if err != nil {
 		t.Fatalf("image build error: %v", err)
 	}
 	defer func() {
@@ -565,7 +566,7 @@ func TestDockerdClient_ImageBuild(t *testing.T) {
 
 	const want = "image build test"
 
-	got, err := dockerRun(t, cli.APIClient, imgRef, want)
+	got, err := dockerRun(t, cli.APIClient, imgID, want)
 	if err != nil {
 		t.Fatalf("docker run error: %v", err)
 	}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -58,7 +58,7 @@ func TestEngine_Run(t *testing.T) {
 
 	const imgRef = "lava-internal-engine-test:go-test"
 
-	if err := cli.ImageBuild(context.Background(), "testdata/engine/lava-engine-test", "Dockerfile", imgRef); err != nil {
+	if _, err := cli.ImageBuild(context.Background(), "testdata/engine/lava-engine-test", "Dockerfile", imgRef); err != nil {
 		t.Fatalf("could build Docker image: %v", err)
 	}
 	defer func() {


### PR DESCRIPTION
This PR fixes a bug when "lava run" builds a Docker image with the
same ID as the previous one. This bug can happen when the checktype
has not changed between runs. In this scenario, the run command would
delete the new image just after building it and before running the
check. If the pull policy is `IfNotPresent`, Docker tries to find an
image with the same name in the configured registry. Otherwise, if the
pull policy is `Never`, Docker fails straight away because the image
is not in the local Docker cache anymore.