### PR TITLE
cmd/lava/internal/run: add -var names to checktype's required vars

### DIFF
--- a/cmd/lava/internal/run/run.go
+++ b/cmd/lava/internal/run/run.go
@@ -393,11 +393,16 @@ func mkAgentConfig() config.AgentConfig {
 // flags and positional arguments.
 func mkChecktypeCatalog(checktype string) checktypes.Catalog {
 	vulcanAssetType := assettypes.ToVulcan(types.AssetType(runType))
+	var reqVars []any
+	for k := range runVar {
+		reqVars = append(reqVars, k)
+	}
 	ct := checkcatalog.Checktype{
-		Name:    checktype,
-		Image:   checktype,
-		Timeout: int(runTimeout.Seconds()),
-		Assets:  []string{vulcanAssetType.String()},
+		Name:         checktype,
+		Image:        checktype,
+		Timeout:      int(runTimeout.Seconds()),
+		Assets:       []string{vulcanAssetType.String()},
+		RequiredVars: reqVars,
 	}
 	return checktypes.Catalog{checktype: ct}
 }


### PR DESCRIPTION
This PR adds the name of the variables passed with the `-var` flag to
the list of required variables of the checktype created by `lava run`
so they are passed to the check.