### PR TITLE
cmd/lava: allow to specify the minimum severity required to show a finding

### DIFF
--- a/cmd/lava/internal/help/helpdoc.go
+++ b/cmd/lava/internal/help/helpdoc.go
@@ -132,9 +132,12 @@ in the configuration file.
 The "report" field describes how to report the findings. It supports
 the following properties.
 
-  - severity: minimum severity required to report a finding. Valid
+  - severity: minimum severity required to exit with error. Valid
     values are "critical", "high", "medium", "low" and "info". If not
     specified, "high" is used.
+  - show: minimum severity required to show a finding. Valid values
+    are "critical", "high", "medium", "low" and "info". If not
+    specified, the severity value is used.
   - format: output format. Valid values are "human" and "json". If not
     specified, "human" is used.
   - output: path of the output file. If not specified, stdout is used.
@@ -149,6 +152,7 @@ The sample below is a full report configuration:
 
 	report:
 	  severity: high
+	  show: low
 	  format: json
 	  output: findings.json
 	  metrics: metrics.json

--- a/cmd/lava/internal/run/run.go
+++ b/cmd/lava/internal/run/run.go
@@ -80,9 +80,13 @@ the first instance of the colon. So the username cannot contain a
 colon. If there is no colon, the password is read from the standard
 input.
 
-The -severity flag determines the minimum severity required to report
-a finding. Valid values are "critical", "high", "medium", "low" and
+The -severity flag determines the minimum severity required to exit
+with error. Valid values are "critical", "high", "medium", "low" and
 "info". If not specified, "high" is used.
+
+The -show flag determines the minimum severity required to show a
+finding. Valid values are "critical", "high", "medium", "low" and
+"info". If not specified, the severity value is used.
 
 The -o flag specifies the output file to write the results of the
 scan. If not specified, the standard output is used. The format of the
@@ -173,6 +177,7 @@ var (
 	runRegistry string                          // -registry flag
 	runUser     userFlag                        // -user flag
 	runSeverity config.Severity                 // -severity flag
+	runShow     showFlag                        // -show flag
 	runO        string                          // -o flag
 	runFmt      config.OutputFormat             // -fmt flag
 	runMetrics  string                          // -metrics flag
@@ -416,11 +421,18 @@ func mkChecktypeCatalog(checktype string) checktypes.Catalog {
 // report. writeOutputs gets the configuration from the provided
 // flags.
 func writeOutputs(rep engine.Report) (report.ExitCode, error) {
+	var showSeverity *config.Severity
+	if runShow.IsSet {
+		showSeverity = &runShow.Value
+	} else {
+		showSeverity = &runSeverity
+	}
 	reportConfig := config.ReportConfig{
-		Severity:   runSeverity,
-		Format:     runFmt,
-		OutputFile: runO,
-		Metrics:    runMetrics,
+		Severity:     runSeverity,
+		ShowSeverity: showSeverity,
+		Format:       runFmt,
+		OutputFile:   runO,
+		Metrics:      runMetrics,
 	}
 	metrics.Collect("severity", reportConfig.Severity)
 

--- a/cmd/lava/internal/run/runflag.go
+++ b/cmd/lava/internal/run/runflag.go
@@ -22,7 +22,7 @@ import (
 type typeFlag types.AssetType
 
 // Set parses the value provided with the -type flag. It returns error
-// if it is not a know asset type.
+// if it is not a known asset type.
 func (typ *typeFlag) Set(s string) error {
 	if s == "" {
 		return errors.New("empty asset type")
@@ -124,6 +124,31 @@ func (userinfo userFlag) String() string {
 	return userinfo.Username + ":****"
 }
 
+// showFlag represents the severity provided with the -show flag.
+type showFlag struct {
+	Value config.Severity
+	IsSet bool
+}
+
+// Set parses the value provided with the -show flag. It returns error
+// if it is not a known severity.
+func (show *showFlag) Set(s string) error {
+	if err := show.Value.UnmarshalText([]byte(s)); err != nil {
+		return err
+	}
+	show.IsSet = true
+	return nil
+}
+
+// String returns the string representation of the provided show
+// value.
+func (show showFlag) String() string {
+	if show.IsSet {
+		return show.Value.String()
+	}
+	return ""
+}
+
 func init() {
 	CmdRun.Flag.Var(&runType, "type", "target type")
 	CmdRun.Flag.DurationVar(&runTimeout, "timeout", 600*time.Second, "checktype timeout")
@@ -133,7 +158,8 @@ func init() {
 	CmdRun.Flag.TextVar(&runPull, "pull", agentconfig.PullPolicyIfNotPresent, "container image pull policy")
 	CmdRun.Flag.StringVar(&runRegistry, "registry", "", "container registry")
 	CmdRun.Flag.Var(&runUser, "user", "container registry credentials")
-	CmdRun.Flag.TextVar(&runSeverity, "severity", config.SeverityHigh, "minimum severity required to report a finding")
+	CmdRun.Flag.TextVar(&runSeverity, "severity", config.SeverityHigh, "minimum severity required to exit with error")
+	CmdRun.Flag.Var(&runShow, "show", "minimum severity required to show a finding")
 	CmdRun.Flag.StringVar(&runO, "o", "", "output file")
 	CmdRun.Flag.TextVar(&runFmt, "fmt", config.OutputFormatHuman, "output format")
 	CmdRun.Flag.StringVar(&runMetrics, "metrics", "", "metrics file")

--- a/cmd/lava/internal/run/runflag_test.go
+++ b/cmd/lava/internal/run/runflag_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/adevinta/lava/internal/assettypes"
+	"github.com/adevinta/lava/internal/config"
 )
 
 func TestTypeFlag_Set(t *testing.T) {
@@ -282,6 +283,73 @@ func TestUserFlag_Set(t *testing.T) {
 			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("userinfo mismatch (-want +got):\n%v", diff)
+			}
+		})
+	}
+}
+
+func TestShowFlag_Set(t *testing.T) {
+	tests := []struct {
+		name       string
+		values     []string
+		want       showFlag
+		wantNilErr []bool
+	}{
+		{
+			name:   "valid",
+			values: []string{"low"},
+			want: showFlag{
+				Value: config.SeverityLow,
+				IsSet: true,
+			},
+			wantNilErr: []bool{true},
+		},
+		{
+			name:       "invalid",
+			values:     []string{"invalid"},
+			want:       showFlag{},
+			wantNilErr: []bool{false},
+		},
+		{
+			name:       "empty",
+			values:     []string{""},
+			want:       showFlag{},
+			wantNilErr: []bool{false},
+		},
+		{
+			name:   "multiple",
+			values: []string{"low", "medium"},
+			want: showFlag{
+				Value: config.SeverityMedium,
+				IsSet: true,
+			},
+			wantNilErr: []bool{true, true},
+		},
+		{
+			name:   "multiple valid invalid",
+			values: []string{"low", "invalid", "medium", "invalid"},
+			want: showFlag{
+				Value: config.SeverityMedium,
+				IsSet: true,
+			},
+			wantNilErr: []bool{true, false, true, false},
+		},
+	}
+
+	for _, tt := range tests {
+		if len(tt.values) != len(tt.wantNilErr) {
+			panic("values and wantNilErr arrays must have the same length")
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			var got showFlag
+			for i, v := range tt.values {
+				if err := got.Set(v); (err == nil) != tt.wantNilErr[i] {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("show mismatch (-want +got):\n%v", diff)
 			}
 		})
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -166,9 +166,13 @@ type AgentConfig struct {
 
 // ReportConfig is the configuration of the report.
 type ReportConfig struct {
-	// Severity is the minimum severity required to report a
-	// finding.
+	// Severity is the minimum severity required to exit with
+	// error.
 	Severity Severity `yaml:"severity"`
+
+	// ShowSeverity is the minimum severity required to show a
+	// finding.
+	ShowSeverity *Severity `yaml:"show"`
 
 	// Format is the output format.
 	Format OutputFormat `yaml:"format"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -137,6 +137,25 @@ func TestParse(t *testing.T) {
 			wantErr: ErrInvalidSeverity,
 		},
 		{
+			name: "low show",
+			file: "testdata/low_show.yaml",
+			want: Config{
+				LavaVersion: "v1.0.0",
+				ChecktypeURLs: []string{
+					"checktypes.json",
+				},
+				ReportConfig: ReportConfig{
+					ShowSeverity: ptr(SeverityLow),
+				},
+				Targets: []Target{
+					{
+						Identifier: "example.com",
+						AssetType:  types.DomainName,
+					},
+				},
+			},
+		},
+		{
 			name: "never pull policy",
 			file: "testdata/never_pull_policy.yaml",
 			want: Config{
@@ -353,4 +372,8 @@ func TestSeverity_MarshalText(t *testing.T) {
 			}
 		})
 	}
+}
+
+func ptr[V any](v V) *V {
+	return &v
 }

--- a/internal/config/testdata/low_show.yaml
+++ b/internal/config/testdata/low_show.yaml
@@ -1,0 +1,8 @@
+lava: v1.0.0
+checktypes:
+  - checktypes.json
+targets:
+  - identifier: example.com
+    type: DomainName
+report:
+  show: low

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1082,6 +1082,170 @@ func TestWriter_filterVulns(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "show",
+			vulnerabilities: []vulnerability{
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 1",
+					},
+					Severity: config.SeverityCritical,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 2",
+					},
+					Severity: config.SeverityHigh,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 3",
+					},
+					Severity: config.SeverityMedium,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 4",
+					},
+					Severity: config.SeverityLow,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 5",
+					},
+					Severity: config.SeverityInfo,
+				},
+			},
+			rConfig: config.ReportConfig{
+				Severity:     config.SeverityCritical,
+				ShowSeverity: ptr(config.SeverityMedium),
+			},
+			want: []vulnerability{
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 1",
+					},
+					Severity: config.SeverityCritical,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 2",
+					},
+					Severity: config.SeverityHigh,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 3",
+					},
+					Severity: config.SeverityMedium,
+				},
+			},
+		},
+		{
+			name: "show higher than severity",
+			vulnerabilities: []vulnerability{
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 1",
+					},
+					Severity: config.SeverityCritical,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 2",
+					},
+					Severity: config.SeverityHigh,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 3",
+					},
+					Severity: config.SeverityMedium,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 4",
+					},
+					Severity: config.SeverityLow,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 5",
+					},
+					Severity: config.SeverityInfo,
+				},
+			},
+			rConfig: config.ReportConfig{
+				Severity:     config.SeverityMedium,
+				ShowSeverity: ptr(config.SeverityHigh),
+			},
+			want: []vulnerability{
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 1",
+					},
+					Severity: config.SeverityCritical,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 2",
+					},
+					Severity: config.SeverityHigh,
+				},
+			},
+		},
+		{
+			name: "default show",
+			vulnerabilities: []vulnerability{
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 1",
+					},
+					Severity: config.SeverityCritical,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 2",
+					},
+					Severity: config.SeverityHigh,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 3",
+					},
+					Severity: config.SeverityMedium,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 4",
+					},
+					Severity: config.SeverityLow,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 5",
+					},
+					Severity: config.SeverityInfo,
+				},
+			},
+			rConfig: config.ReportConfig{
+				Severity: config.SeverityHigh,
+			},
+			want: []vulnerability{
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 1",
+					},
+					Severity: config.SeverityCritical,
+				},
+				{
+					Vulnerability: vreport.Vulnerability{
+						Summary: "Vulnerability Summary 2",
+					},
+					Severity: config.SeverityHigh,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1289,4 +1453,8 @@ func statusLess(a, b checkStatus) bool {
 		return fmt.Sprintf("%#v", v)
 	}
 	return h(a) < h(b)
+}
+
+func ptr[V any](v V) *V {
+	return &v
 }


### PR DESCRIPTION
This PR adds the field `report.show` to the Lava configuration
file. It allows to specify the minimum severity required to show a
finding. Similarly, it adds the flag `-show` to the `lava run`
command.

This change allows to use different severity thresholds to exit with
error and to generate the report.