### PR TITLE
internal/report/human: add fingerprint, split resource rows

### DIFF
--- a/cmd/lava/internal/help/helpdoc.go
+++ b/cmd/lava/internal/help/helpdoc.go
@@ -167,9 +167,7 @@ The exclusion rules support the following filters:
     target.
   - resource: regular expression that matches the name of the affected
     resource.
-  - fingerprint: context in where the vulnerability has been found. It
-    includes the checktype image, the affected target, the asset type
-    and the checktype options.
+  - fingerprint: context in where the vulnerability has been found.
   - summary: regular expression that matches the summary of the
     vulnerability.
   - expiration: is the date on which the exclusion becomes inactive.

--- a/internal/report/human.tmpl
+++ b/internal/report/human.tmpl
@@ -157,8 +157,8 @@ Number of excluded vulnerabilities not included in the summary table: {{.Exclude
 {{- define "vulnRsc" -}}
 {{- $rsc := . -}}
 - {{$rsc.Name | bold}}:
-{{- range $row := $rsc.Rows}}{{range $header := $rsc.Header}}
-  {{$header | trim | bold}}: {{index $row $header | trim -}}
+{{- range $row := $rsc.Rows}}{{range $i, $header := $rsc.Header}}
+  {{if eq $i 0}}- {{else}}  {{end}}{{ $header | trim | bold}}: {{index $row $header | trim -}}
 {{end}}{{end}}
 {{- end -}}
 

--- a/internal/report/human.tmpl
+++ b/internal/report/human.tmpl
@@ -76,6 +76,11 @@ Number of excluded vulnerabilities not included in the summary table: {{.Exclude
 {{$affectedResource | trim}}
 {{end -}}
 
+{{- if .Fingerprint}}
+{{"FINGERPRINT" | bold}}
+{{.Fingerprint | trim}}
+{{end -}}
+
 {{- if .Description}}
 {{"DESCRIPTION" | bold}}
 {{.Description | trim}}


### PR DESCRIPTION
This PR implements two changes in Lava's human-readable output:

- Show vulnerability fingerprint, so it is easier to exclude
  vulnerabilities by this criteria.
- Split resource rows with hyphens, so it is easier to read the
  resource tables.

Before,

```
=== [GO-2021-0113] Out-of-bounds read in golang.org/x/text/language (HIGH) ===

TARGET
/home/n/tmp/govulncheck-test/

AFFECTED RESOURCE
Module golang.org/x/text@v0.3.5 at sub1/go.mod:1

DESCRIPTION
Out-of-bounds read in golang.org/x/text/language

DETAILS
Your code calls vulnerable functions in 1 package (golang.org/x/text/language).

RECOMMENDATIONS
- Visit the linked references for more details.

REFERENCES
- https://pkg.go.dev/vuln/GO-2021-0113

RESOURCES
- A summarized code flow for vulnerable function golang.org/x/text/language.Parse:
  module: sub1@
  location: %SRCROOT%/main.go:12:29
  function: sub1.main
  module: golang.org/x/text@v0.3.5
  location: %GOMODCACHE%/golang.org/x/text@v0.3.5/language/parse.go:33:6
  function: golang.org/x/text/language.Parse
```

After,

```
=== [GO-2021-0113] Out-of-bounds read in golang.org/x/text/language (HIGH) ===

TARGET
/home/n/tmp/govulncheck-test/

AFFECTED RESOURCE
Module golang.org/x/text@v0.3.5 at sub1/go.mod:1

FINGERPRINT
30832915d775c6f522564e815d0322facca4598bf72427ad5c93281026b351a6

DESCRIPTION
Out-of-bounds read in golang.org/x/text/language

DETAILS
Your code calls vulnerable functions in 1 package (golang.org/x/text/language).

RECOMMENDATIONS
- Visit the linked references for more details.

REFERENCES
- https://pkg.go.dev/vuln/GO-2021-0113

RESOURCES
- A summarized code flow for vulnerable function golang.org/x/text/language.Parse:
  - module: sub1@
    location: %SRCROOT%/main.go:12:29
    function: sub1.main
  - module: golang.org/x/text@v0.3.5
    location: %GOMODCACHE%/golang.org/x/text@v0.3.5/language/parse.go:33:6
    function: golang.org/x/text/language.Parse
```