### PR TITLE
internal/config: allow nils for settings with default values

### DIFF
--- a/cmd/lava/internal/run/run.go
+++ b/cmd/lava/internal/run/run.go
@@ -255,7 +255,7 @@ func engineRun(targetIdent string, checktype string) (engine.Report, error) {
 	case err != nil && !errors.Is(err, fs.ErrNotExist):
 		return nil, err
 	case err == nil && info.IsDir():
-		if agentConfig.PullPolicy != agentconfig.PullPolicyIfNotPresent && agentConfig.PullPolicy != agentconfig.PullPolicyNever {
+		if config.Get(agentConfig.PullPolicy) != agentconfig.PullPolicyIfNotPresent && config.Get(agentConfig.PullPolicy) != agentconfig.PullPolicyNever {
 			return nil, errors.New("path checktypes only allow IfNotPresent and Never pull policies")
 		}
 
@@ -392,7 +392,7 @@ func mkAgentConfig() config.AgentConfig {
 	}
 
 	return config.AgentConfig{
-		PullPolicy:    runPull,
+		PullPolicy:    &runPull,
 		Vars:          runVar,
 		RegistryAuths: auths,
 	}
@@ -428,11 +428,11 @@ func writeOutputs(rep engine.Report) (report.ExitCode, error) {
 		showSeverity = &runSeverity
 	}
 	reportConfig := config.ReportConfig{
-		Severity:     runSeverity,
+		Severity:     &runSeverity,
 		ShowSeverity: showSeverity,
-		Format:       runFmt,
-		OutputFile:   runO,
-		Metrics:      runMetrics,
+		Format:       &runFmt,
+		OutputFile:   &runO,
+		Metrics:      &runMetrics,
 	}
 	metrics.Collect("severity", reportConfig.Severity)
 
@@ -447,8 +447,8 @@ func writeOutputs(rep engine.Report) (report.ExitCode, error) {
 		return 0, fmt.Errorf("render report: %w", err)
 	}
 
-	if reportConfig.Metrics != "" {
-		if err = metrics.WriteFile(reportConfig.Metrics); err != nil {
+	if metricsFile := config.Get(reportConfig.Metrics); metricsFile != "" {
+		if err = metrics.WriteFile(metricsFile); err != nil {
 			return 0, fmt.Errorf("write metrics: %w", err)
 		}
 	}

--- a/cmd/lava/internal/scan/scan.go
+++ b/cmd/lava/internal/scan/scan.go
@@ -96,7 +96,7 @@ func scan(args []string) (int, error) {
 		return 0, fmt.Errorf("parse config file: %w", err)
 	}
 
-	base.LogLevel.Set(cfg.LogLevel)
+	base.LogLevel.Set(config.Get(cfg.LogLevel))
 
 	bi, ok := debugReadBuildInfo()
 	if !ok {
@@ -109,10 +109,10 @@ func scan(args []string) (int, error) {
 	}
 
 	metrics.Collect("lava_version", bi.Main.Version)
-	metrics.Collect("config_version", cfg.LavaVersion)
+	metrics.Collect("config_version", config.Get(cfg.LavaVersion))
 	metrics.Collect("checktype_urls", cfg.ChecktypeURLs)
 	metrics.Collect("targets", cfg.Targets)
-	metrics.Collect("severity", cfg.ReportConfig.Severity)
+	metrics.Collect("severity", config.Get(cfg.ReportConfig.Severity))
 	metrics.Collect("exclusion_count", len(cfg.ReportConfig.Exclusions))
 
 	eng, err := engine.New(cfg.AgentConfig, cfg.ChecktypeURLs)
@@ -140,8 +140,8 @@ func scan(args []string) (int, error) {
 	metrics.Collect("exit_code", exitCode)
 	metrics.Collect("duration", time.Since(startTime).Seconds())
 
-	if cfg.ReportConfig.Metrics != "" {
-		if err = metrics.WriteFile(cfg.ReportConfig.Metrics); err != nil {
+	if metricsFile := config.Get(cfg.ReportConfig.Metrics); metricsFile != "" {
+		if err = metrics.WriteFile(metricsFile); err != nil {
 			return 0, fmt.Errorf("write metrics: %w", err)
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,7 +60,7 @@ var (
 // Config represents a Lava configuration.
 type Config struct {
 	// LavaVersion is the minimum required version of Lava.
-	LavaVersion string `yaml:"lava"`
+	LavaVersion *string `yaml:"lava"`
 
 	// AgentConfig is the configuration of the vulcan-agent.
 	AgentConfig AgentConfig `yaml:"agent"`
@@ -76,7 +76,7 @@ type Config struct {
 	Targets []Target `yaml:"targets"`
 
 	// LogLevel is the logging level.
-	LogLevel slog.Level `yaml:"log"`
+	LogLevel *slog.Level `yaml:"log"`
 }
 
 // reEnv is used to replace embedded environment variables.
@@ -123,7 +123,7 @@ func ParseFile(path string) (Config, error) {
 // validate validates the Lava configuration.
 func (c Config) validate() error {
 	// Lava version validation.
-	if !semver.IsValid(c.LavaVersion) {
+	if !semver.IsValid(Get(c.LavaVersion)) {
 		return ErrInvalidLavaVersion
 	}
 
@@ -148,17 +148,17 @@ func (c Config) validate() error {
 // the specified version. An invalid semantic version string is
 // considered incompatible.
 func (c Config) IsCompatible(v string) bool {
-	return semver.Compare(v, c.LavaVersion) >= 0
+	return semver.Compare(v, Get(c.LavaVersion)) >= 0
 }
 
 // AgentConfig is the configuration passed to the vulcan-agent.
 type AgentConfig struct {
 	// PullPolicy is the pull policy passed to vulcan-agent.
-	PullPolicy agentconfig.PullPolicy `yaml:"pullPolicy"`
+	PullPolicy *agentconfig.PullPolicy `yaml:"pullPolicy"`
 
 	// Parallel is the maximum number of checks that can run in
 	// parallel.
-	Parallel int `yaml:"parallel"`
+	Parallel *int `yaml:"parallel"`
 
 	// Vars is the environment variables required by the Vulcan
 	// checktypes.
@@ -173,17 +173,17 @@ type AgentConfig struct {
 type ReportConfig struct {
 	// Severity is the minimum severity required to exit with
 	// error.
-	Severity Severity `yaml:"severity"`
+	Severity *Severity `yaml:"severity"`
 
 	// ShowSeverity is the minimum severity required to show a
 	// finding.
 	ShowSeverity *Severity `yaml:"show"`
 
 	// Format is the output format.
-	Format OutputFormat `yaml:"format"`
+	Format *OutputFormat `yaml:"format"`
 
 	// OutputFile is the path of the output file.
-	OutputFile string `yaml:"output"`
+	OutputFile *string `yaml:"output"`
 
 	// Exclusions is a list of findings that will be ignored. For
 	// instance, accepted risks, false positives, etc.
@@ -191,12 +191,12 @@ type ReportConfig struct {
 
 	// ErrorOnStaleExclusions specifies whether Lava should exit
 	// with error when stale exclusions are detected.
-	ErrorOnStaleExclusions bool `yaml:"errorOnStaleExclusions"`
+	ErrorOnStaleExclusions *bool `yaml:"errorOnStaleExclusions"`
 
 	// Metrics is the file where the metrics will be written.
 	// If Metrics is an empty string or not specified in the yaml file, then
 	// the metrics report is not saved.
-	Metrics string `yaml:"metrics"`
+	Metrics *string `yaml:"metrics"`
 }
 
 // Target represents the target of a scan.
@@ -445,4 +445,14 @@ func (ed ExpirationDate) MarshalText() (text []byte, err error) {
 // String returns the string representation of the expiration date.
 func (ed ExpirationDate) String() string {
 	return ed.Format(ExpirationDateLayout)
+}
+
+// Get returns the value of a pointer or the zero value if the pointer
+// is nil.
+func Get[T any](p *T) T {
+	var v T
+	if p != nil {
+		v = *p
+	}
+	return v
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -29,7 +29,7 @@ func TestParse(t *testing.T) {
 			name: "valid",
 			file: "testdata/valid.yaml",
 			want: Config{
-				LavaVersion: "v1.0.0",
+				LavaVersion: ptr("v1.0.0"),
 				ChecktypeURLs: []string{
 					"checktypes.json",
 				},
@@ -45,7 +45,7 @@ func TestParse(t *testing.T) {
 			name: "valid env",
 			file: "testdata/valid_env.yaml",
 			want: Config{
-				LavaVersion: "v1.0.0",
+				LavaVersion: ptr("v1.0.0"),
 				ChecktypeURLs: []string{
 					"checktypes.json",
 				},
@@ -65,7 +65,7 @@ func TestParse(t *testing.T) {
 			name: "invalid env",
 			file: "testdata/invalid_env.yaml",
 			want: Config{
-				LavaVersion: "v1.0.0",
+				LavaVersion: ptr("v1.0.0"),
 				ChecktypeURLs: []string{
 					"checktypes.json",
 				},
@@ -117,12 +117,12 @@ func TestParse(t *testing.T) {
 			name: "critical severity",
 			file: "testdata/critical_severity.yaml",
 			want: Config{
-				LavaVersion: "v1.0.0",
+				LavaVersion: ptr("v1.0.0"),
 				ChecktypeURLs: []string{
 					"checktypes.json",
 				},
 				ReportConfig: ReportConfig{
-					Severity: SeverityCritical,
+					Severity: ptr(SeverityCritical),
 				},
 				Targets: []Target{
 					{
@@ -142,7 +142,7 @@ func TestParse(t *testing.T) {
 			name: "low show",
 			file: "testdata/low_show.yaml",
 			want: Config{
-				LavaVersion: "v1.0.0",
+				LavaVersion: ptr("v1.0.0"),
 				ChecktypeURLs: []string{
 					"checktypes.json",
 				},
@@ -161,12 +161,12 @@ func TestParse(t *testing.T) {
 			name: "never pull policy",
 			file: "testdata/never_pull_policy.yaml",
 			want: Config{
-				LavaVersion: "v1.0.0",
+				LavaVersion: ptr("v1.0.0"),
 				ChecktypeURLs: []string{
 					"checktypes.json",
 				},
 				AgentConfig: AgentConfig{
-					PullPolicy: agentconfig.PullPolicyNever,
+					PullPolicy: ptr(agentconfig.PullPolicyNever),
 				},
 				Targets: []Target{
 					{
@@ -192,7 +192,7 @@ func TestParse(t *testing.T) {
 			name: "JSON output format",
 			file: "testdata/json_output_format.yaml",
 			want: Config{
-				LavaVersion: "v1.0.0",
+				LavaVersion: ptr("v1.0.0"),
 				ChecktypeURLs: []string{
 					"checktypes.json",
 				},
@@ -203,7 +203,7 @@ func TestParse(t *testing.T) {
 					},
 				},
 				ReportConfig: ReportConfig{
-					Format: OutputFormatJSON,
+					Format: ptr(OutputFormatJSON),
 				},
 			},
 		},
@@ -217,7 +217,7 @@ func TestParse(t *testing.T) {
 			name: "debug log level",
 			file: "testdata/debug_log_level.yaml",
 			want: Config{
-				LavaVersion: "v1.0.0",
+				LavaVersion: ptr("v1.0.0"),
 				ChecktypeURLs: []string{
 					"checktypes.json",
 				},
@@ -227,7 +227,7 @@ func TestParse(t *testing.T) {
 						AssetType:  types.DomainName,
 					},
 				},
-				LogLevel: slog.LevelDebug,
+				LogLevel: ptr(slog.LevelDebug),
 			},
 		},
 		{
@@ -240,7 +240,7 @@ func TestParse(t *testing.T) {
 			name: "valid expiration date",
 			file: "testdata/valid_expiration_date.yaml",
 			want: Config{
-				LavaVersion: "v1.0.0",
+				LavaVersion: ptr("v1.0.0"),
 				ChecktypeURLs: []string{
 					"checktypes.json",
 				},
@@ -251,8 +251,6 @@ func TestParse(t *testing.T) {
 					},
 				},
 				ReportConfig: ReportConfig{
-					Format:     OutputFormatHuman,
-					OutputFile: "",
 					Exclusions: []Exclusion{
 						{
 							Summary:        "Secret Leaked in Git Repository",
@@ -310,31 +308,31 @@ func TestConfig_IsCompatible(t *testing.T) {
 	}{
 		{
 			name: "same version",
-			cfg:  Config{LavaVersion: "v1.0.0"},
+			cfg:  Config{LavaVersion: ptr("v1.0.0")},
 			v:    "v1.0.0",
 			want: true,
 		},
 		{
 			name: "lower version",
-			cfg:  Config{LavaVersion: "v1.1.0"},
+			cfg:  Config{LavaVersion: ptr("v1.1.0")},
 			v:    "1.0.0",
 			want: false,
 		},
 		{
 			name: "higher version",
-			cfg:  Config{LavaVersion: "v1.0.0"},
+			cfg:  Config{LavaVersion: ptr("v1.0.0")},
 			v:    "v1.1.0",
 			want: true,
 		},
 		{
 			name: "pre-release",
-			cfg:  Config{LavaVersion: "v0.0.0"},
+			cfg:  Config{LavaVersion: ptr("v0.0.0")},
 			v:    "v0.0.0-20231216173526-1150d51c5272",
 			want: false,
 		},
 		{
 			name: "invalid version",
-			cfg:  Config{LavaVersion: "v1.0.0"},
+			cfg:  Config{LavaVersion: ptr("v1.0.0")},
 			v:    "invalid",
 			want: false,
 		},

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -91,7 +91,7 @@ func newAgentConfig(cli containers.DockerdClient, cfg config.AgentConfig) (agent
 		return agentconfig.Config{}, fmt.Errorf("get gateway interface address: %w", err)
 	}
 
-	parallel := cfg.Parallel
+	parallel := config.Get(cfg.Parallel)
 	if parallel == 0 {
 		parallel = 1
 	}
@@ -127,7 +127,7 @@ func newAgentConfig(cli containers.DockerdClient, cfg config.AgentConfig) (agent
 		Runtime: agentconfig.RuntimeConfig{
 			Docker: agentconfig.DockerConfig{
 				Registry: agentconfig.RegistryConfig{
-					PullPolicy:          cfg.PullPolicy,
+					PullPolicy:          config.Get(cfg.PullPolicy),
 					BackoffMaxRetries:   5,
 					BackoffInterval:     5,
 					BackoffJitterFactor: 0.5,

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -86,7 +86,7 @@ func TestEngine_Run(t *testing.T) {
 			},
 		}
 		agentConfig = config.AgentConfig{
-			PullPolicy: agentconfig.PullPolicyNever,
+			PullPolicy: ptr(agentconfig.PullPolicyNever),
 		}
 	)
 
@@ -143,7 +143,7 @@ func TestEngine_Run_docker_image(t *testing.T) {
 			},
 		}
 		agentConfig = config.AgentConfig{
-			PullPolicy: agentconfig.PullPolicyAlways,
+			PullPolicy: ptr(agentconfig.PullPolicyAlways),
 		}
 	)
 
@@ -186,7 +186,7 @@ func TestEngine_Run_path(t *testing.T) {
 	var (
 		checktypeURLs = []string{"testdata/engine/checktypes_trivy.json"}
 		agentConfig   = config.AgentConfig{
-			PullPolicy: agentconfig.PullPolicyAlways,
+			PullPolicy: ptr(agentconfig.PullPolicyAlways),
 		}
 	)
 
@@ -259,7 +259,7 @@ func TestEngine_Run_unreachable_target(t *testing.T) {
 	var (
 		checktypeURLs = []string{"testdata/engine/checktypes_trivy.json"}
 		agentConfig   = config.AgentConfig{
-			PullPolicy: agentconfig.PullPolicyAlways,
+			PullPolicy: ptr(agentconfig.PullPolicyAlways),
 		}
 		target = config.Target{
 			Identifier: "testdata/engine/notexist",
@@ -282,7 +282,7 @@ func TestEngine_Run_not_repo(t *testing.T) {
 	var (
 		checktypeURLs = []string{"testdata/engine/checktypes_trivy.json"}
 		agentConfig   = config.AgentConfig{
-			PullPolicy: agentconfig.PullPolicyAlways,
+			PullPolicy: ptr(agentconfig.PullPolicyAlways),
 		}
 		target = config.Target{
 			Identifier: "testdata/engine/vulnpath",
@@ -317,7 +317,7 @@ func TestEngine_Run_no_jobs(t *testing.T) {
 	var (
 		checktypeURLs = []string{"testdata/engine/checktypes_lava_engine_test.json"}
 		agentConfig   = config.AgentConfig{
-			PullPolicy: agentconfig.PullPolicyNever,
+			PullPolicy: ptr(agentconfig.PullPolicyNever),
 		}
 	)
 
@@ -349,4 +349,8 @@ func checkReportTarget(t *testing.T, report Report, substr string) {
 	if strings.Contains(string(doc), substr) {
 		t.Errorf("report contains %q:\n%s", substr, doc)
 	}
+}
+
+func ptr[V any](v V) *V {
+	return &v
 }

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -38,7 +38,7 @@ var timeNow = time.Now
 // NewWriter creates a new instance of a report writer.
 func NewWriter(cfg config.ReportConfig) (Writer, error) {
 	var prn printer
-	switch cfg.Format {
+	switch config.Get(cfg.Format) {
 	case config.OutputFormatHuman:
 		prn = humanPrinter{}
 	case config.OutputFormatJSON:
@@ -49,8 +49,8 @@ func NewWriter(cfg config.ReportConfig) (Writer, error) {
 
 	w := os.Stdout
 	isStdout := true
-	if cfg.OutputFile != "" {
-		f, err := os.Create(cfg.OutputFile)
+	if outputFile := config.Get(cfg.OutputFile); outputFile != "" {
+		f, err := os.Create(outputFile)
 		if err != nil {
 			return Writer{}, fmt.Errorf("create file: %w", err)
 		}
@@ -62,17 +62,17 @@ func NewWriter(cfg config.ReportConfig) (Writer, error) {
 	if cfg.ShowSeverity != nil {
 		showSeverity = *cfg.ShowSeverity
 	} else {
-		showSeverity = cfg.Severity
+		showSeverity = config.Get(cfg.Severity)
 	}
 
 	return Writer{
 		prn:                    prn,
 		w:                      w,
 		isStdout:               isStdout,
-		minSeverity:            cfg.Severity,
+		minSeverity:            config.Get(cfg.Severity),
 		showSeverity:           showSeverity,
 		exclusions:             cfg.Exclusions,
-		errorOnStaleExclusions: cfg.ErrorOnStaleExclusions,
+		errorOnStaleExclusions: config.Get(cfg.ErrorOnStaleExclusions),
 	}, nil
 }
 

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -46,7 +46,7 @@ func TestWriter_calculateExitCode(t *testing.T) {
 				},
 			},
 			rConfig: config.ReportConfig{
-				Severity: config.SeverityInfo,
+				Severity: ptr(config.SeverityInfo),
 			},
 			want: ExitCodeCritical,
 		},
@@ -69,7 +69,7 @@ func TestWriter_calculateExitCode(t *testing.T) {
 				},
 			},
 			rConfig: config.ReportConfig{
-				Severity: config.SeverityInfo,
+				Severity: ptr(config.SeverityInfo),
 			},
 			want: ExitCodeHigh,
 		},
@@ -92,7 +92,7 @@ func TestWriter_calculateExitCode(t *testing.T) {
 				},
 			},
 			rConfig: config.ReportConfig{
-				Severity: config.SeverityInfo,
+				Severity: ptr(config.SeverityInfo),
 			},
 			want: ExitCodeMedium,
 		},
@@ -115,7 +115,7 @@ func TestWriter_calculateExitCode(t *testing.T) {
 				},
 			},
 			rConfig: config.ReportConfig{
-				Severity: config.SeverityInfo,
+				Severity: ptr(config.SeverityInfo),
 			},
 			want: ExitCodeLow,
 		},
@@ -138,7 +138,7 @@ func TestWriter_calculateExitCode(t *testing.T) {
 				},
 			},
 			rConfig: config.ReportConfig{
-				Severity: config.SeverityInfo,
+				Severity: ptr(config.SeverityInfo),
 			},
 			want: ExitCodeInfo,
 		},
@@ -162,7 +162,7 @@ func TestWriter_calculateExitCode(t *testing.T) {
 			},
 
 			rConfig: config.ReportConfig{
-				Severity: config.SeverityHigh,
+				Severity: ptr(config.SeverityHigh),
 			},
 			want: 0,
 		},
@@ -185,7 +185,7 @@ func TestWriter_calculateExitCode(t *testing.T) {
 				},
 			},
 			rConfig: config.ReportConfig{
-				Severity: config.SeverityHigh,
+				Severity: ptr(config.SeverityHigh),
 			},
 			want: ExitCodeCheckError,
 		},
@@ -208,7 +208,7 @@ func TestWriter_calculateExitCode(t *testing.T) {
 				},
 			},
 			rConfig: config.ReportConfig{
-				Severity: config.SeverityHigh,
+				Severity: ptr(config.SeverityHigh),
 			},
 			want: ExitCodeCheckError,
 		},
@@ -236,7 +236,7 @@ func TestWriter_calculateExitCode(t *testing.T) {
 				},
 			},
 			rConfig: config.ReportConfig{
-				Severity: config.SeverityHigh,
+				Severity: ptr(config.SeverityHigh),
 				Exclusions: []config.Exclusion{
 					{
 						Summary: "Unused exclusion",
@@ -269,8 +269,8 @@ func TestWriter_calculateExitCode(t *testing.T) {
 				},
 			},
 			rConfig: config.ReportConfig{
-				Severity:               config.SeverityHigh,
-				ErrorOnStaleExclusions: true,
+				Severity:               ptr(config.SeverityHigh),
+				ErrorOnStaleExclusions: ptr(true),
 				Exclusions: []config.Exclusion{
 					{
 						Summary: "Unused exclusion",
@@ -1117,7 +1117,7 @@ func TestWriter_filterVulns(t *testing.T) {
 				},
 			},
 			rConfig: config.ReportConfig{
-				Severity: config.SeverityInfo,
+				Severity: ptr(config.SeverityInfo),
 			},
 			want: []vulnerability{
 				{
@@ -1232,7 +1232,7 @@ func TestWriter_filterVulns(t *testing.T) {
 				},
 			},
 			rConfig: config.ReportConfig{
-				Severity: config.SeverityHigh,
+				Severity: ptr(config.SeverityHigh),
 			},
 			want: []vulnerability{
 				{
@@ -1286,7 +1286,7 @@ func TestWriter_filterVulns(t *testing.T) {
 				},
 			},
 			rConfig: config.ReportConfig{
-				Severity:     config.SeverityCritical,
+				Severity:     ptr(config.SeverityCritical),
 				ShowSeverity: ptr(config.SeverityMedium),
 			},
 			want: []vulnerability{
@@ -1345,7 +1345,7 @@ func TestWriter_filterVulns(t *testing.T) {
 				},
 			},
 			rConfig: config.ReportConfig{
-				Severity:     config.SeverityMedium,
+				Severity:     ptr(config.SeverityMedium),
 				ShowSeverity: ptr(config.SeverityHigh),
 			},
 			want: []vulnerability{
@@ -1398,7 +1398,7 @@ func TestWriter_filterVulns(t *testing.T) {
 				},
 			},
 			rConfig: config.ReportConfig{
-				Severity: config.SeverityHigh,
+				Severity: ptr(config.SeverityHigh),
 			},
 			want: []vulnerability{
 				{
@@ -1573,9 +1573,9 @@ func TestNewWriter_OutputFile(t *testing.T) {
 				},
 			},
 			rConfig: config.ReportConfig{
-				Severity:   config.SeverityInfo,
-				OutputFile: "test.json",
-				Format:     config.OutputFormatJSON,
+				Severity:   ptr(config.SeverityInfo),
+				OutputFile: ptr("test.json"),
+				Format:     ptr(config.OutputFormatJSON),
 			},
 			wantExitCode: ExitCodeInfo,
 			wantNilErr:   true,
@@ -1589,7 +1589,7 @@ func TestNewWriter_OutputFile(t *testing.T) {
 			}
 			defer os.RemoveAll(tmpPath)
 
-			tt.rConfig.OutputFile = path.Join(tmpPath, tt.rConfig.OutputFile)
+			tt.rConfig.OutputFile = ptr(path.Join(tmpPath, config.Get(tt.rConfig.OutputFile)))
 			writer, err := NewWriter(tt.rConfig)
 			if err != nil {
 				t.Fatalf("unable to create a report writer: %v", err)
@@ -1603,7 +1603,7 @@ func TestNewWriter_OutputFile(t *testing.T) {
 				t.Errorf("unexpected error value: got: %d, want: %d", gotExitCode, tt.wantExitCode)
 			}
 
-			if _, err = os.Stat(tt.rConfig.OutputFile); err != nil {
+			if _, err = os.Stat(config.Get(tt.rConfig.OutputFile)); err != nil {
 				t.Fatalf("unexpected error value: %v", err)
 			}
 		})


### PR DESCRIPTION
As part of the future development of the functionality that will allow importing configurations, we need to be able to distinguish those settings that have not been specified in the configuration but which until now have been automatically assigned a default value.
Therefore, these settings are now converted into pointers.