### PR TITLE
internal/config: walk the graph and merge configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,14 +91,7 @@ func Parse(path string) (Config, error) {
 	if err != nil {
 		return Config{}, fmt.Errorf("build dag: %w", err)
 	}
-	if err = graph.Resolve(); err != nil {
-		return Config{}, fmt.Errorf("resolve dag: %w", err)
-	}
-
-	cfg, err := graph.Config(path)
-	if err != nil {
-		return Config{}, fmt.Errorf("unknown configuration: %w", err)
-	}
+	cfg := graph.Resolve()
 
 	if err = cfg.validate(); err != nil {
 		return Config{}, fmt.Errorf("validate config: %w", err)

--- a/internal/config/dag/dag.go
+++ b/internal/config/dag/dag.go
@@ -94,3 +94,17 @@ func (d *DAG) getVertexID(s string) string {
 	}
 	return ""
 }
+
+// WalkFunc represents a function that implements the [hdag.Visitor]
+// interface.
+type WalkFunc func(vertexID string, vertex interface{})
+
+// Visit is required by the [hdag.Visitor] interface.
+func (fn WalkFunc) Visit(v hdag.Vertexer) {
+	fn(v.Vertex())
+}
+
+// DFSWalk walks the [DAG] using a depth first strategy.
+func (d *DAG) DFSWalk(fn WalkFunc) {
+	d.dag.DFSWalk(fn)
+}

--- a/internal/config/testdata/include/common.yaml
+++ b/internal/config/testdata/include/common.yaml
@@ -7,3 +7,5 @@ checktypes:
 targets:
   - identifier: example.com
     type: DomainName
+report:
+  severity: critical

--- a/internal/config/testdata/include/common_a.yaml
+++ b/internal/config/testdata/include/common_a.yaml
@@ -6,3 +6,5 @@ checktypes:
 targets:
   - identifier: example.com
     type: DomainName
+report:
+  severity: medium

--- a/internal/config/testdata/include/no_includes.yaml
+++ b/internal/config/testdata/include/no_includes.yaml
@@ -1,6 +1,6 @@
 lava: v1.0.0
 checktypes:
-  - checktypes.json
+  - checktypes_no_includes.json
 targets:
   - identifier: example.com
     type: DomainName


### PR DESCRIPTION
This PR adds the functionality to walk the graph representing the configuration and resolve the final configuration by merging the included configuration files every time a node is visited.