### PR TITLE
Locate exclusions

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -405,6 +405,13 @@ type Exclusion struct {
 
 	// Description describes the exclusion.
 	Description string `yaml:"description"`
+
+	// URL is where the exclusion has been declared.
+	URL string
+
+	// Index is the position in the list of exclusions in the original
+	// configuration.
+	Index int
 }
 
 // ExpirationDateLayout is the input format for the [ExpirationDate].

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -406,12 +406,8 @@ type Exclusion struct {
 	// Description describes the exclusion.
 	Description string `yaml:"description"`
 
-	// URL is where the exclusion has been declared.
-	URL string
-
-	// Index is the position in the list of exclusions in the original
-	// configuration.
-	Index int
+	// Location is where the exclusion has been declared.
+	Location string
 }
 
 // ExpirationDateLayout is the input format for the [ExpirationDate].

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -256,6 +256,7 @@ func TestParse(t *testing.T) {
 							Summary:        "Secret Leaked in Git Repository",
 							Description:    "Ignore test certificates.",
 							ExpirationDate: mustParseExpDate("2024/07/05"),
+							Location:       "testdata/valid_expiration_date.yaml",
 						},
 					},
 				},

--- a/internal/config/configgraph.go
+++ b/internal/config/configgraph.go
@@ -61,8 +61,7 @@ func discoverConfig(url, parent string, d *dag.DAG, configs map[string]Config) e
 	}
 	// Locate the exclusions.
 	for i := range cfg.ReportConfig.Exclusions {
-		cfg.ReportConfig.Exclusions[i].Index = i
-		cfg.ReportConfig.Exclusions[i].URL = url
+		cfg.ReportConfig.Exclusions[i].Location = url
 	}
 	configs[url] = cfg
 
@@ -81,7 +80,7 @@ func discoverConfig(url, parent string, d *dag.DAG, configs map[string]Config) e
 	return nil
 }
 
-// Config returns a configuration for the given URL.
+// Config returns a configuration for the given Location.
 func (cg *ConfigGraph) Config(url string) (Config, error) {
 	if cfg, ok := cg.configs[url]; ok {
 		return cfg, nil

--- a/internal/config/configgraph.go
+++ b/internal/config/configgraph.go
@@ -59,6 +59,11 @@ func discoverConfig(url, parent string, d *dag.DAG, configs map[string]Config) e
 	if err != nil {
 		return fmt.Errorf("could not decode include config: %w", err)
 	}
+	// Locate the exclusions.
+	for i := range cfg.ReportConfig.Exclusions {
+		cfg.ReportConfig.Exclusions[i].Index = i
+		cfg.ReportConfig.Exclusions[i].URL = url
+	}
 	configs[url] = cfg
 
 	unique := make(map[string]struct{})

--- a/internal/report/human.tmpl
+++ b/internal/report/human.tmpl
@@ -195,7 +195,9 @@ Number of excluded vulnerabilities not included in the summary table: {{.Exclude
 {{- if not .ExpirationDate.IsZero}}
 {{- $pref}}{{"Expiration Date" | bold}}: {{.ExpirationDate.String | trim}}{{$pref = "  "}}
 {{end -}}
+{{- if .Location}}
+{{- $pref}}{{"Location" | bold}}: {{.Location | trim}}{{$pref = "  "}}
+{{end -}}
 {{- end -}}
-
 {{- /* Render the report. */ -}}
 {{- template "report" . -}}


### PR DESCRIPTION
Locate each exclusion in its configuration file to provide accurate information about that to the users.
